### PR TITLE
chore: versioned abi

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ docker-compose up -d
 
 The subgraphs manifests are automatically generated using the [prepare script](./scripts/prepare.ts), which uses `@requestnetwork/smart-contracts` NPM package to get the smart-contracts addresses.
 
+One manifest can refer to many different versions of proxies dealing with the same payment network. The first version found is not explicitely mentionned in generated files and data sources naming. Example; `EthProxy` implicitely refers to the version `0.1.0`. Further versions are referenced in this format: `EthProxy_0_2_0` for the contract `EthProxy` of abi version `0.2.0`.
+
 > Note: The `TransferWithReferenceAndFee` event is configured twice. That is because the Conversion proxy makes an internal call to the ERC20 Fee proxy. Both `TransferWithReferenceAndFee` and `TransferWithConversionAndReference` need to be parsed for the Conversion smart-contract.
 
 ## Deployment

--- a/abis/ERC20FeeProxy-0.2.0.json
+++ b/abis/ERC20FeeProxy-0.2.0.json
@@ -1,0 +1,90 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes",
+        "name": "paymentReference",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "feeAddress",
+        "type": "address"
+      }
+    ],
+    "name": "TransferWithReferenceAndFee",
+    "type": "event"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_paymentReference",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_feeAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_feeAddress",
+        "type": "address"
+      }
+    ],
+    "name": "transferFromWithReferenceAndFee",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/EthConversionProxy-0.2.0.json
+++ b/abis/EthConversionProxy-0.2.0.json
@@ -1,0 +1,270 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_paymentProxyAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_chainlinkConversionPathAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_nativeTokenHash",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "currency",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes",
+        "name": "paymentReference",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxRateTimespan",
+        "type": "uint256"
+      }
+    ],
+    "name": "TransferWithConversionAndReference",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes",
+        "name": "paymentReference",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "feeAddress",
+        "type": "address"
+      }
+    ],
+    "name": "TransferWithReferenceAndFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "WhitelistAdminAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "WhitelistAdminRemoved",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addWhitelistAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "chainlinkConversionPath",
+    "outputs": [
+      {
+        "internalType": "contract ChainlinkConversionPath",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isWhitelistAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nativeTokenHash",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paymentProxy",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceWhitelistAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_requestAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_paymentReference",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_feeAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_feeAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxRateTimespan",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferWithReferenceAndFee",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_chainlinkConversionPathAddress",
+        "type": "address"
+      }
+    ],
+    "name": "updateConversionPathAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_paymentProxyAddress",
+        "type": "address"
+      }
+    ],
+    "name": "updateConversionProxyAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/EthProxy-0.2.0.json
+++ b/abis/EthProxy-0.2.0.json
@@ -1,0 +1,52 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes",
+        "name": "paymentReference",
+        "type": "bytes"
+      }
+    ],
+    "name": "TransferWithReference",
+    "type": "event"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_paymentReference",
+        "type": "bytes"
+      }
+    ],
+    "name": "transferWithReference",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "0.20.0",
     "@graphprotocol/graph-ts": "0.20.0",
-    "@requestnetwork/smart-contracts": "0.28.1-next.1605"
+    "@requestnetwork/smart-contracts": "0.28.1-next.1630"
   },
   "devDependencies": {
     "@types/mustache": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "0.20.0",
     "@graphprotocol/graph-ts": "0.20.0",
-    "@requestnetwork/smart-contracts": "0.28.1-next.1630"
+    "@requestnetwork/smart-contracts": "0.28.1-next.1631"
   },
   "devDependencies": {
     "@types/mustache": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "0.20.0",
     "@graphprotocol/graph-ts": "0.20.0",
-    "@requestnetwork/smart-contracts": "0.28.1-next.1631"
+    "@requestnetwork/smart-contracts": "0.28.1-next.1634"
   },
   "devDependencies": {
     "@types/mustache": "^4.1.1",

--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -95,7 +95,6 @@ for (const network of networks) {
             .replace(/([\w]+) indexed/, "indexed $1"),
         }));
       const abiName = i === 0 ? pn : `${pn}-${version}`;
-      console.log(abiName.replace(/[\-\.]/g, "_"));
       dataSources.push({
         abiName,
         name: abiName.replace(/[\-\.]/g, "_"),

--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -71,6 +71,9 @@ for (const [pn, artifact] of Object.entries(paymentNetworks)) {
   );
 }
 
+// Ignore events that are not payment related
+const ignoredEvents = ["WhitelistAdminAdded", "WhitelistAdminRemoved"];
+
 for (const network of networks) {
   const dataSources: DataSource[] = [];
 
@@ -87,6 +90,7 @@ for (const network of networks) {
       const events = artifact
         .getContractAbi(version)
         .filter((x) => x.type === "event")
+        .filter((x) => x.name && !ignoredEvents.includes(x.name))
         .map((x) => ({
           handlerName: "handle" + x.name,
           eventSignature: EventFragment.fromObject(x)

--- a/subgraph.fantom.yaml
+++ b/subgraph.fantom.yaml
@@ -106,4 +106,26 @@ dataSources:
         - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
           handler: handleTransferWithReferenceAndFee
       file: ./src/ethConversionProxy.ts
+  - kind: ethereum/contract
+    name: EthConversionProxy_0_2_0
+    network: fantom
+    source:
+      address: "0x7Ebf48a26253810629C191b56C3212Fd0D211c26"
+      abi: EthConversionProxy_0_2_0
+      startBlock: 28552915
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthConversionProxy_0_2_0
+          file: ./abis/EthConversionProxy-0.2.0.json
+      eventHandlers:
+        - event: TransferWithConversionAndReference(uint256,address,indexed bytes,uint256,uint256)
+          handler: handleTransferWithConversionAndReference
+        - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+      file: ./src/ethConversionProxy.ts
   

--- a/subgraph.mainnet.yaml
+++ b/subgraph.mainnet.yaml
@@ -85,11 +85,11 @@ dataSources:
           handler: handleTransferWithReference
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
-    name: EthProxy-0.2.0
+    name: EthProxy_0_2_0
     network: mainnet
     source:
       address: "0x27c60BE17e853c47A9F1d280B05365f483c2dFAF"
-      abi: EthProxy
+      abi: EthProxy_0_2_0
       startBlock: 13764023
     mapping:
       kind: ethereum/events
@@ -98,8 +98,8 @@ dataSources:
       entities:
         - Payment
       abis:
-        - name: EthProxy
-          file: ./abis/EthProxy.json
+        - name: EthProxy_0_2_0
+          file: ./abis/EthProxy-0.2.0.json
       eventHandlers:
         - event: TransferWithReference(address,uint256,indexed bytes)
           handler: handleTransferWithReference

--- a/subgraph.matic.yaml
+++ b/subgraph.matic.yaml
@@ -23,11 +23,11 @@ dataSources:
           handler: handleTransferWithReferenceAndFee
       file: ./src/erc20FeeProxy.ts
   - kind: ethereum/contract
-    name: ERC20FeeProxy-0.2.0
+    name: ERC20FeeProxy_0_2_0
     network: matic
     source:
       address: "0x0DfbEe143b42B41eFC5A6F87bFD1fFC78c2f0aC9"
-      abi: ERC20FeeProxy
+      abi: ERC20FeeProxy_0_2_0
       startBlock: 17427742
     mapping:
       kind: ethereum/events
@@ -36,8 +36,8 @@ dataSources:
       entities:
         - Payment
       abis:
-        - name: ERC20FeeProxy
-          file: ./abis/ERC20FeeProxy.json
+        - name: ERC20FeeProxy_0_2_0
+          file: ./abis/ERC20FeeProxy-0.2.0.json
       eventHandlers:
         - event: TransferWithReferenceAndFee(address,address,uint256,indexed bytes,uint256,address)
           handler: handleTransferWithReferenceAndFee

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -146,4 +146,30 @@ dataSources:
         - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
           handler: handleTransferWithReferenceAndFee
       file: ./src/ethConversionProxy.ts
+  - kind: ethereum/contract
+    name: EthConversionProxy_0_2_0
+    network: rinkeby
+    source:
+      address: "0x7Ebf48a26253810629C191b56C3212Fd0D211c26"
+      abi: EthConversionProxy_0_2_0
+      startBlock: 10023415
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthConversionProxy_0_2_0
+          file: ./abis/EthConversionProxy-0.2.0.json
+      eventHandlers:
+        - event: TransferWithConversionAndReference(uint256,address,indexed bytes,uint256,uint256)
+          handler: handleTransferWithConversionAndReference
+        - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+        - event: WhitelistAdminAdded(indexed address)
+          handler: handleWhitelistAdminAdded
+        - event: WhitelistAdminRemoved(indexed address)
+          handler: handleWhitelistAdminRemoved
+      file: ./src/ethConversionProxy.ts
   

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -167,9 +167,5 @@ dataSources:
           handler: handleTransferWithConversionAndReference
         - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
           handler: handleTransferWithReferenceAndFee
-        - event: WhitelistAdminAdded(indexed address)
-          handler: handleWhitelistAdminAdded
-        - event: WhitelistAdminRemoved(indexed address)
-          handler: handleWhitelistAdminRemoved
       file: ./src/ethConversionProxy.ts
   

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -85,11 +85,11 @@ dataSources:
           handler: handleTransferWithReference
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
-    name: EthProxy-0.2.0
+    name: EthProxy_0_2_0
     network: rinkeby
     source:
       address: "0x27c60BE17e853c47A9F1d280B05365f483c2dFAF"
-      abi: EthProxy
+      abi: EthProxy_0_2_0
       startBlock: 9447186
     mapping:
       kind: ethereum/events
@@ -98,8 +98,8 @@ dataSources:
       entities:
         - Payment
       abis:
-        - name: EthProxy
-          file: ./abis/EthProxy.json
+        - name: EthProxy_0_2_0
+          file: ./abis/EthProxy-0.2.0.json
       eventHandlers:
         - event: TransferWithReference(address,uint256,indexed bytes)
           handler: handleTransferWithReference

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -8,7 +8,7 @@ dataSources:
     network: {{network}}
     source:
       address: "{{address}}"
-      abi: {{abiName}}
+      abi: {{name}}
       startBlock: {{creationBlockNumber}}
     mapping:
       kind: ethereum/events
@@ -17,7 +17,7 @@ dataSources:
       entities:
         - Payment
       abis:
-        - name: {{abiName}}
+        - name: {{name}}
           file: ./abis/{{abiName}}.json
       eventHandlers:
         {{#events}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,10 +402,12 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@requestnetwork/smart-contracts@0.28.1-next.1589":
-  version "0.28.1-next.1589"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.28.1-next.1589.tgz#d0cd16f3a2d2ebffd486eabda3e210c2f0d8b973"
-  integrity sha512-yQB6rzpxPp2KLWXTGaP06Fj/qWKTpN64buFq247P0l+0A+CLjxCu7S3P2ntVqByOVU0rJ48KSr6EHVa9cLB9YA==
+"@requestnetwork/smart-contracts@0.28.1-next.1630":
+  version "0.28.1-next.1630"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.28.1-next.1630.tgz#0cbff06948b354d64c57a6bd64421d4955531242"
+  integrity sha512-86Z8f922uQ+XFwPsudzq/yFkA1pxkVYKPY/yKStw4XkZFNCY45f4XLtDTZWt1Lk2p3Xi2WXr18S/4sjA9Ck3+A==
+  dependencies:
+    tslib "2.3.1"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
@@ -3357,6 +3359,11 @@ ts-node@^10.0.0:
     make-error "^1.1.1"
     source-map-support "^0.5.17"
     yn "3.1.1"
+
+tslib@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,10 +402,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@requestnetwork/smart-contracts@0.28.1-next.1631":
-  version "0.28.1-next.1631"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.28.1-next.1631.tgz#6567fa8c2c8e869a38ecae0c44ce4349851d453b"
-  integrity sha512-a9RE1r1wG4SirMdNNtwtcqlBVyh5RPa+pg8RM5NZgyV+3z2qGrvalQ6ceIWY3Wd5cfRFdyMKhbD2KdPfP3LBiw==
+"@requestnetwork/smart-contracts@0.28.1-next.1634":
+  version "0.28.1-next.1634"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.28.1-next.1634.tgz#33e12e8bce2e973501c8ab635b73eaccfe53b0eb"
+  integrity sha512-Z4jFEkic9ArNH7D+ceaAomD0JNksel7um4n/NZCwsBly7TQzgqi5DO+aJBkEcEtQ4gx7S6PKcYXMsF+uAPAmfw==
   dependencies:
     tslib "2.3.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,10 +402,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@requestnetwork/smart-contracts@0.28.1-next.1630":
-  version "0.28.1-next.1630"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.28.1-next.1630.tgz#0cbff06948b354d64c57a6bd64421d4955531242"
-  integrity sha512-86Z8f922uQ+XFwPsudzq/yFkA1pxkVYKPY/yKStw4XkZFNCY45f4XLtDTZWt1Lk2p3Xi2WXr18S/4sjA9Ck3+A==
+"@requestnetwork/smart-contracts@0.28.1-next.1631":
+  version "0.28.1-next.1631"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.28.1-next.1631.tgz#6567fa8c2c8e869a38ecae0c44ce4349851d453b"
+  integrity sha512-a9RE1r1wG4SirMdNNtwtcqlBVyh5RPa+pg8RM5NZgyV+3z2qGrvalQ6ceIWY3Wd5cfRFdyMKhbD2KdPfP3LBiw==
   dependencies:
     tslib "2.3.1"
 


### PR DESCRIPTION
chore:
- Different versions of a payment network can have different ABI

deployment update:
- EthConversionProxy v0.2.0 on rinkeby