### PR TITLE
feat: added proxy payment address field to Escrow entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -33,6 +33,7 @@ enum EscrowState {
 type Escrow @entity {
   id: ID!
   contractAddress: Bytes!
+  paymentProxyAddress: Bytes!
   reference: Bytes!
   creationBlock: Int!
   creationTimestamp: Int!

--- a/schema.graphql
+++ b/schema.graphql
@@ -42,8 +42,8 @@ type Escrow @entity {
   amount: BigDecimal!
   feeAmount: BigDecimal!
   feeAddress: Bytes!
-  payer: Bytes!
-  payee: Bytes
+  from: Bytes!
+  to: Bytes
   events: [EscrowEvent!] @derivedFrom(field: "escrow")
 }
 

--- a/src/erc20EscrowToPay.ts
+++ b/src/erc20EscrowToPay.ts
@@ -6,6 +6,7 @@ import {
 } from "../generated/ERC20EscrowToPay/ERC20EscrowToPay";
 import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy/ERC20FeeProxy";
 import { Escrow } from "../generated/schema";
+import { ERC20EscrowToPay } from "../generated/ERC20EscrowToPay/ERC20EscrowToPay";
 import { createPaymentForFeeProxy } from "./erc20FeeProxy";
 import { generateEscrowId, createEscrowEvent } from "./shared";
 
@@ -25,8 +26,10 @@ export function handleTransferWithReferenceAndFee(
   let escrowId = generateEscrowId(paymentReference);
   let escrow = Escrow.load(escrowId);
   if (escrow == null) {
+    let escrowContract = ERC20EscrowToPay.bind(event.address);
     escrow = new Escrow(escrowId);
     escrow.contractAddress = event.address;
+    escrow.paymentProxyAddress = escrowContract.paymentProxy();
     escrow.reference = paymentReference;
     escrow.creationBlock = event.block.number.toI32();
     escrow.creationTimestamp = event.block.timestamp.toI32();

--- a/src/erc20EscrowToPay.ts
+++ b/src/erc20EscrowToPay.ts
@@ -38,7 +38,7 @@ export function handleTransferWithReferenceAndFee(
     escrow.feeAmount = event.params.feeAmount.toBigDecimal();
     escrow.feeAddress = event.params.feeAddress;
     escrow.escrowState = "paidEscrow";
-    escrow.payer = event.transaction.from;
+    escrow.from = event.transaction.from;
     escrow.save();
   }
   createEscrowEvent(event, event.params.paymentReference, "paidEscrow");

--- a/src/erc20FeeProxy.ts
+++ b/src/erc20FeeProxy.ts
@@ -38,7 +38,7 @@ export function handleTransferWithReferenceAndFee(
   let escrow = Escrow.load(escrowId);
   if (escrow) {
     escrow.escrowState = "paidIssuer";
-    escrow.payee = payment.to;
+    escrow.to = payment.to;
     escrow.save();
     createEscrowEvent(event, paymentReference, "paidIssuer");
   }


### PR DESCRIPTION
The Escrow contract uses a payment proxy to perform the transfers.
Currently it uses the Erc20FeeProxy contract for transfers, but the transfer events themselves are emitted by the Escrow contract, and because of this the  contractAddress field is populated by the Escrow contract address, in the Escrow entity.

This PR adds new field to the Escrow entity for storing the payment proxy address. This is required for us to be able to fetch both payments and escrows events in single call.