### PR TITLE
ci: subgraph deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,9 @@ jobs:
     strategy:
       matrix:
         chain: ["arbitrum-one", "arbitrum-rinkeby", "avalanche", "bsc", "celo", "fantom", "fuse", "goerli", "mainnet", "matic", "rinkeby", "xdai"]
-    environment: ${{ matrix.chain }}
+    environment: 
+      name: ${{ matrix.chain }}
+      url: https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-${{ matrix.chain }}
     steps:
       - uses: actions/checkout@v3
       - name: Get yarn cache directory path

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,4 +10,12 @@ jobs:
         chain: ["arbitrum-one", "arbitrum-rinkeby", "avalanche", "bsc", "celo", "fantom", "fuse", "goerli", "mainnet", "matic", "rinkeby", "xdai"]
     environment: ${{ matrix.chain }}
     steps:
-      - run: echo "hello"
+      - uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn
+      - run: yarn subgraph deploy ${{ matrix.chain }}
+        env:
+          TOKEN: ${{ secrets.THEGRAPH_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 name: Deploy subgraph
 on:
   push:
-    branches: ["ci"]
+    branches: ["main"]
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,8 +10,12 @@ jobs:
         chain: ["arbitrum-one", "arbitrum-rinkeby", "avalanche", "bsc", "celo", "fantom", "fuse", "goerli", "mainnet", "matic", "rinkeby", "xdai"]
     environment: ${{ matrix.chain }}
     steps:
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v3
         with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,14 @@
+name: Deploy subgraph
+on:
+  push:
+    branches: ["ci"]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chain: ["rinkeby", "goerli"]
+    environment: ${{ matrix.chain }}
+    steps:
+      - run: echo "hello"
+      

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,7 @@ jobs:
         chain: ["arbitrum-one", "arbitrum-rinkeby", "avalanche", "bsc", "celo", "fantom", "fuse", "goerli", "mainnet", "matic", "rinkeby", "xdai"]
     environment: ${{ matrix.chain }}
     steps:
+      - uses: actions/checkout@v3
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,8 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chain: ["rinkeby", "goerli"]
+        chain: ["arbitrum-one", "arbitrum-rinkeby", "avalanche", "bsc", "celo", "fantom", "fuse", "goerli", "mainnet", "matic", "rinkeby", "xdai"]
     environment: ${{ matrix.chain }}
     steps:
       - run: echo "hello"
-      

--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ One manifest can refer to many different versions of proxies dealing with the sa
 
 ## Deployment
 
-> Hint: You can get your token from your [Dashboard](https://thegraph.com/hosted-service/dashboard), under RequestNetwork organization.
-
 ### Local
 
 ```
@@ -73,15 +71,10 @@ yarn deploy-local
 
 ### Networks
 
-```
-export TOKEN=xxx
-# deploy on one network
-yarn subgraph deploy rinkeby
-# deploy on multiple networks
-yarn subgraph deploy matic xdai
-# or, to deploy all networks
-yarn subgraph deploy --all
-```
+The live deployment is automated. 
+For test chains (rinkeby, goerli), it will be automatically deployed when pushed to `main`
+
+For production chains (all others), it is semi automatic, and requires a manual approval in [github actions](https://github.com/RequestNetwork/payments-subgraph/actions).
 
 ### Check the deployed version
 You can compare the code to the deployed version using one of these commands

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ docker-compose up -d
 # Run
 ```
 
+### Adding a new chain
+> This requires the `@requestnetwork/smart-contracts` package to be deployed. 
+```
+export NETWORK=my-network
+
+# update to latest version
+yarn add --exact @requestnetwork/smart-contracts@next
+
+# add new network
+cat <<< $(jq '. + [env.NETWORK] | unique' cli/networks.json) > cli/networks.json
+
+# update CI (update deployment targets with cli/networks.json)
+NETWORKS=$(cat ./cli/networks.json) yq e -i '.jobs.deploy.strategy.matrix.chain |= env(NETWORKS)' .github/workflows/deploy.yaml
+
+# create Github Environment (for CI) based on mainnet
+yarn subgraph configure-ci $NETWORK
+```
+
 ## Manifests
 
 The subgraphs manifests are automatically generated using the [prepare script](./scripts/prepare.ts), which uses `@requestnetwork/smart-contracts` NPM package to get the smart-contracts addresses.

--- a/cli/commands/compare.ts
+++ b/cli/commands/compare.ts
@@ -2,7 +2,7 @@ import { existsSync } from "fs";
 import { writeFile, readFile } from "fs/promises";
 import path from "path";
 import yargs, { array } from "yargs";
-import { networks } from "../lib/networks";
+import networks from "../networks.json";
 import { compile } from "../lib/compile";
 import { getStatus } from "../lib/status";
 

--- a/cli/commands/configure-ci.ts
+++ b/cli/commands/configure-ci.ts
@@ -1,0 +1,73 @@
+import yargs from "yargs";
+import networks from "../networks.json";
+import { exec } from "child_process";
+
+export const command = "configure-ci [network..]";
+export const desc = "Deploys one subgraph";
+export const builder = (y: yargs.Argv) =>
+  y.positional("network", {
+    desc: "The network to deploy to",
+    type: "string",
+    array: true,
+    choices: networks.filter(x => x !== "mainnet"),
+  });
+
+const gh = async <T = any>(
+  args: string,
+  { method, input }: { method?: string; input?: unknown } = {},
+) => {
+  let params = ["gh", "api", args];
+  if (method) {
+    params.push("-X");
+    params.push(method);
+  }
+  // hack for input formatted as json: https://github.com/cli/cli/issues/1484
+  if (input) {
+    params = [
+      "jq",
+      "-n",
+      `'${JSON.stringify(input)}'`,
+      "|",
+      ...params,
+      "--input",
+      "-",
+    ];
+  }
+
+  return await new Promise<T>((resolve, reject) =>
+    exec(params.join(" "), (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(JSON.parse(stdout));
+      }
+    }),
+  );
+};
+
+export const handler = async ({
+  network,
+}: Awaited<ReturnType<typeof builder>["argv"]>) => {
+  // Get the mainnet configuration
+  const mainnet = await gh<{
+    protection_rules: {
+      reviewers: { type: string; reviewer: { id: number } }[];
+    }[];
+    deployment_branch_policy: any;
+  }>("repos/:owner/:repo/environments/mainnet");
+
+  // format the reviewers field
+  const reviewers = mainnet.protection_rules[0]?.reviewers.map(
+    ({ type, reviewer }) => ({ type, id: reviewer.id }),
+  );
+
+  // create or update the environment based on mainnet values
+  const r = await gh(`repos/:owner/:repo/environments/${network}`, {
+    method: "PUT",
+    input: {
+      reviewers,
+      deployment_branch_policy: mainnet.deployment_branch_policy,
+    },
+  });
+  console.log(r);
+};

--- a/cli/commands/deploy.ts
+++ b/cli/commands/deploy.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { deploySubgraph } from "../lib/deploy";
-import { networks } from "../lib/networks";
+import networks from "../networks.json";
 
 export const command = "deploy [network..]";
 export const desc = "Deploys one subgraph";

--- a/cli/commands/monitor.ts
+++ b/cli/commands/monitor.ts
@@ -1,5 +1,5 @@
 import yargs from "yargs";
-import { networks } from "../lib/networks";
+import networks from "../networks.json";
 import { getDelay } from "../lib/delay";
 
 export const command = "monitor";

--- a/cli/commands/prepare.ts
+++ b/cli/commands/prepare.ts
@@ -1,4 +1,4 @@
-import { networks } from "../lib/networks";
+import networks from "../networks.json";
 import { getManifest } from "../lib/manifest";
 import { writeFile } from "fs/promises";
 

--- a/cli/networks.json
+++ b/cli/networks.json
@@ -1,4 +1,4 @@
-export const networks = [
+[
   "mainnet",
   "rinkeby",
   "goerli",
@@ -10,5 +10,5 @@ export const networks = [
   "bsc",
   "avalanche",
   "arbitrum-one",
-  "arbitrum-rinkeby",
-];
+  "arbitrum-rinkeby"
+]

--- a/cli/networks.json
+++ b/cli/networks.json
@@ -1,14 +1,14 @@
 [
-  "mainnet",
-  "rinkeby",
-  "goerli",
-  "xdai",
-  "fuse",
-  "matic",
+  "arbitrum-one",
+  "arbitrum-rinkeby",
+  "avalanche",
+  "bsc",
   "celo",
   "fantom",
-  "bsc",
-  "avalanche",
-  "arbitrum-one",
-  "arbitrum-rinkeby"
+  "fuse",
+  "goerli",
+  "mainnet",
+  "matic",
+  "rinkeby",
+  "xdai"
 ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "codegen": "graph codegen ./subgraph.rinkeby.yaml",
-    "prepare": "yarn subgraph prepare &&  yarn codegen",
+    "update-ci": "NETWORKS=$(cat ./cli/networks.json) yq e -i '.jobs.deploy.strategy.matrix.chain |= env(NETWORKS)' .github/workflows/deploy.yaml",
+    "prepare": "yarn subgraph prepare && yarn codegen && yarn update-ci",
     "build": "graph build",
     "create-local": "graph create --node http://localhost:8020/ --access-token \"\" requestnetwork/request-payments-$NETWORK",
     "remove-local": "graph remove --node http://localhost:8020/ --access-token \"\" requestnetwork/request-payments-$NETWORK",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   },
   "scripts": {
     "codegen": "graph codegen ./subgraph.rinkeby.yaml",
-    "update-ci": "NETWORKS=$(cat ./cli/networks.json) yq e -i '.jobs.deploy.strategy.matrix.chain |= env(NETWORKS)' .github/workflows/deploy.yaml",
-    "prepare": "yarn subgraph prepare && yarn codegen && yarn update-ci",
+    "prepare": "yarn subgraph prepare && yarn codegen",
     "build": "graph build",
     "create-local": "graph create --node http://localhost:8020/ --access-token \"\" requestnetwork/request-payments-$NETWORK",
     "remove-local": "graph remove --node http://localhost:8020/ --access-token \"\" requestnetwork/request-payments-$NETWORK",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Proposal

Automate the subgraphs deployment to avoid forgetting them.
The push occurs when merged to master for test chains. 
For non-test chains, a validation step is required (one click for all, or 1 by 1)