### PR TITLE
feat: add mantle and mantle-testnet

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chain: ["arbitrum-one", "avalanche", "bsc", "celo", "fantom", "fuse", "goerli", "mainnet", "matic", "xdai"]
-    environment: 
+        chain: ["arbitrum-one", "avalanche", "bsc", "celo", "fantom", "fuse", "goerli", "mainnet", "mantle-testnet", "mantle", "matic", "xdai", "optimism", "moonbeam", "tombchain"]
+    environment:
       name: ${{ matrix.chain }}
       url: https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-${{ matrix.chain }}
     steps:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ This repo contains the code and configuration for Request Payment subgraphs:
 - [Fuse](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-fuse)
 - [Fantom](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-fantom)
 - [Near](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-near)
+- [Avalanche](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-avalanche)
+- [Optimism](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-optimism)
+- [Moonbeam](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-moonbeam)
+- [Arbitrum One](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-arbitrum-one)
+- [Mantle](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-mantle)
+- [Goerli](https://thegraph.com/explorer/subgraph/requestnetwork/request-payments-goerli)
+- [Near Testnet](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-near-testnet)
+- [Arbitrum Rinkeby](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-arbitrum-rinkeby)
+- [Mantle Testnet](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-mantle-testnet)
 
 It indexes Request's proxy smart-contracts for easy querying of payment data.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This repo contains the code and configuration for Request Payment subgraphs:
 
+Mainnets:
 - [Mainnet](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-mainnet)
 - [Polygon (Matic)](https://thegraph.com/explorer/subgraph/requestnetwork/request-payments-matic)
 - [Celo](https://thegraph.com/explorer/subgraph/requestnetwork/request-payments-celo)
@@ -14,11 +15,13 @@ This repo contains the code and configuration for Request Payment subgraphs:
 - [Optimism](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-optimism)
 - [Moonbeam](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-moonbeam)
 - [Arbitrum One](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-arbitrum-one)
-- [Mantle](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-mantle)
+- [Mantle](https://graph.fusionx.finance/subgraphs/name/request-payments-mantle/graphql)
+
+Testnets:
 - [Goerli](https://thegraph.com/explorer/subgraph/requestnetwork/request-payments-goerli)
 - [Near Testnet](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-near-testnet)
 - [Arbitrum Rinkeby](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-arbitrum-rinkeby)
-- [Mantle Testnet](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-mantle-testnet)
+- [Mantle Testnet](https://graph.testnet.mantle.xyz/subgraphs/name/request-payments-mantle-testnet/graphql)
 
 It indexes Request's proxy smart-contracts for easy querying of payment data.
 

--- a/cli/commands/deploy.ts
+++ b/cli/commands/deploy.ts
@@ -44,6 +44,7 @@ export const handler = ({
         `requestnetwork/request-payments-${net}`,
         `./subgraph.${net}.yaml`,
         {
+          // Graph Node maintained by Mantle Foundation: https://docs.mantle.xyz/network/for-devs/resources-and-tooling/graph-endpoints
           ipfs: "https://ipfs.testnet.mantle.xyz/",
           node: "https://graph.testnet.mantle.xyz/deploy/",
         },
@@ -53,6 +54,7 @@ export const handler = ({
         `requestnetwork/request-payments-${net}`,
         `./subgraph.${net}.yaml`,
         {
+          // Graph Node maintained by FusionX: https://fusionx.finance/
           ipfs: "https://api.thegraph.com/ipfs/",
           node: "https://deploy.graph.fusionx.finance/",
         },

--- a/cli/commands/deploy.ts
+++ b/cli/commands/deploy.ts
@@ -39,14 +39,36 @@ export const handler = ({
   const networkList = all ? networks : network || [];
   for (const net of networkList) {
     console.log(`Deploy on ${net}`);
+    if (net === "mantle-testnet") {
+      deploySubgraph(
+        `requestnetwork/request-payments-${net}`,
+        `./subgraph.${net}.yaml`,
+        {
+          ipfs: "https://ipfs.testnet.mantle.xyz/",
+          node: "https://graph.testnet.mantle.xyz/deploy/",
+        },
+      )
+    } else if (net === "mantle") {
+      deploySubgraph(
+        `requestnetwork/request-payments-${net}`,
+        `./subgraph.${net}.yaml`,
+        {
+          ipfs: "https://api.thegraph.com/ipfs/",
+          node: "https://deploy.graph.fusionx.finance/",
+        },
+      )
+    } else {
     deploySubgraph(
       `requestnetwork/request-payments-${net}`,
       `./subgraph.${net}.yaml`,
       {
         ipfs: "https://api.thegraph.com/ipfs/",
         node: "https://api.thegraph.com/deploy/",
+      },
+      {
         "access-token": token,
       },
     );
   }
+}
 };

--- a/cli/lib/deploy.ts
+++ b/cli/lib/deploy.ts
@@ -11,7 +11,7 @@ export const deploySubgraph = (
     "access-token": string;
   }
 ) => {
-  let argsString = Object.entries({...args, ...options})
+  const argsString = Object.entries({...args, ...options})
     .map(([name, value]) => `--${name} ${value}`)
     .join(" ");
 

--- a/cli/lib/deploy.ts
+++ b/cli/lib/deploy.ts
@@ -1,5 +1,4 @@
 import { execSync } from "child_process";
-import util from "util";
 
 export const deploySubgraph = (
   subgraphName: string,
@@ -7,10 +6,12 @@ export const deploySubgraph = (
   args: {
     node: string;
     ipfs: string;
-    "access-token": string;
   },
+  options?: {
+    "access-token": string;
+  }
 ) => {
-  const argsString = Object.entries(args)
+  let argsString = Object.entries({...args, ...options})
     .map(([name, value]) => `--${name} ${value}`)
     .join(" ");
 

--- a/cli/networks.json
+++ b/cli/networks.json
@@ -7,6 +7,8 @@
   "fuse",
   "goerli",
   "mainnet",
+  "mantle-testnet",
+  "mantle",
   "matic",
   "xdai",
   "optimism",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.33.0",
     "@graphprotocol/graph-ts": "^0.27.0",
-    "@requestnetwork/smart-contracts": "0.29.1-next.1869",
+    "@requestnetwork/smart-contracts": "0.29.1-next.1917",
     "graphql-request": "^3.5.0",
     "ipfs-only-hash": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.54.0",
     "@graphprotocol/graph-ts": "^0.27.0",
-    "@requestnetwork/smart-contracts": "0.29.1-next.1917",
+    "@requestnetwork/smart-contracts": "0.29.1-next.1918",
     "graphql-request": "^3.5.0",
     "ipfs-only-hash": "^4.0.0",
     "lodash": "^4.17.21"

--- a/subgraph.mantle-testnet.yaml
+++ b/subgraph.mantle-testnet.yaml
@@ -1,0 +1,88 @@
+specVersion: 0.0.5
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ERC20Proxy
+    network: mantle-testnet
+    source:
+      address: "0x88Ecc15fDC2985A7926171B938BB2Cd808A5ba40"
+      abi: ERC20Proxy
+      startBlock: 16210085
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: ERC20Proxy
+          file: ./abis/ERC20Proxy.json
+      eventHandlers:
+        - event: TransferWithReference(address,address,uint256,indexed bytes)
+          handler: handleTransferWithReference
+          receipt: true
+      file: ./src/erc20Proxy.ts
+  - kind: ethereum/contract
+    name: ERC20FeeProxy
+    network: mantle-testnet
+    source:
+      address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
+      abi: ERC20FeeProxy
+      startBlock: 16210087
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: ERC20FeeProxy
+          file: ./abis/ERC20FeeProxy.json
+      eventHandlers:
+        - event: TransferWithReferenceAndFee(address,address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+          receipt: true
+      file: ./src/erc20FeeProxy.ts
+  - kind: ethereum/contract
+    name: EthProxy_0_3_0
+    network: mantle-testnet
+    source:
+      address: "0x171Ee0881407d4c0C11eA1a2FB7D5b4cdED71e6e"
+      abi: EthProxy_0_3_0
+      startBlock: 16210080
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthProxy_0_3_0
+          file: ./abis/EthProxy-0.3.0.json
+      eventHandlers:
+        - event: TransferWithReference(address,uint256,indexed bytes)
+          handler: handleTransferWithReference
+          receipt: true
+      file: ./src/ethProxy.ts
+  - kind: ethereum/contract
+    name: EthFeeProxy_0_2_0
+    network: mantle-testnet
+    source:
+      address: "0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687"
+      abi: EthFeeProxy_0_2_0
+      startBlock: 16210081
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthFeeProxy_0_2_0
+          file: ./abis/EthFeeProxy-0.2.0.json
+      eventHandlers:
+        - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+          receipt: true
+      file: ./src/ethFeeProxy.ts

--- a/subgraph.mantle-testnet.yaml
+++ b/subgraph.mantle-testnet.yaml
@@ -24,11 +24,11 @@ dataSources:
           receipt: true
       file: ./src/erc20Proxy.ts
   - kind: ethereum/contract
-    name: ERC20FeeProxy
+    name: ERC20FeeProxy_0_2_0
     network: mantle-testnet
     source:
       address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
-      abi: ERC20FeeProxy
+      abi: ERC20FeeProxy_0_2_0
       startBlock: 16210087
     mapping:
       kind: ethereum/events
@@ -37,8 +37,8 @@ dataSources:
       entities:
         - Payment
       abis:
-        - name: ERC20FeeProxy
-          file: ./abis/ERC20FeeProxy.json
+        - name: ERC20FeeProxy_0_2_0
+          file: ./abis/ERC20FeeProxy-0.2.0.json
       eventHandlers:
         - event: TransferWithReferenceAndFee(address,address,uint256,indexed bytes,uint256,address)
           handler: handleTransferWithReferenceAndFee

--- a/subgraph.mantle.yaml
+++ b/subgraph.mantle.yaml
@@ -24,11 +24,11 @@ dataSources:
           receipt: true
       file: ./src/erc20Proxy.ts
   - kind: ethereum/contract
-    name: ERC20FeeProxy
+    name: ERC20FeeProxy_0_2_0
     network: mantle
     source:
       address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
-      abi: ERC20FeeProxy
+      abi: ERC20FeeProxy_0_2_0
       startBlock: 127951
     mapping:
       kind: ethereum/events
@@ -37,8 +37,8 @@ dataSources:
       entities:
         - Payment
       abis:
-        - name: ERC20FeeProxy
-          file: ./abis/ERC20FeeProxy.json
+        - name: ERC20FeeProxy_0_2_0
+          file: ./abis/ERC20FeeProxy-0.2.0.json
       eventHandlers:
         - event: TransferWithReferenceAndFee(address,address,uint256,indexed bytes,uint256,address)
           handler: handleTransferWithReferenceAndFee

--- a/subgraph.mantle.yaml
+++ b/subgraph.mantle.yaml
@@ -1,0 +1,88 @@
+specVersion: 0.0.5
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ERC20Proxy
+    network: mantle
+    source:
+      address: "0x88Ecc15fDC2985A7926171B938BB2Cd808A5ba40"
+      abi: ERC20Proxy
+      startBlock: 127947
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: ERC20Proxy
+          file: ./abis/ERC20Proxy.json
+      eventHandlers:
+        - event: TransferWithReference(address,address,uint256,indexed bytes)
+          handler: handleTransferWithReference
+          receipt: true
+      file: ./src/erc20Proxy.ts
+  - kind: ethereum/contract
+    name: ERC20FeeProxy
+    network: mantle
+    source:
+      address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
+      abi: ERC20FeeProxy
+      startBlock: 127951
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: ERC20FeeProxy
+          file: ./abis/ERC20FeeProxy.json
+      eventHandlers:
+        - event: TransferWithReferenceAndFee(address,address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+          receipt: true
+      file: ./src/erc20FeeProxy.ts
+  - kind: ethereum/contract
+    name: EthProxy_0_3_0
+    network: mantle
+    source:
+      address: "0x171Ee0881407d4c0C11eA1a2FB7D5b4cdED71e6e"
+      abi: EthProxy_0_3_0
+      startBlock: 127942
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthProxy_0_3_0
+          file: ./abis/EthProxy-0.3.0.json
+      eventHandlers:
+        - event: TransferWithReference(address,uint256,indexed bytes)
+          handler: handleTransferWithReference
+          receipt: true
+      file: ./src/ethProxy.ts
+  - kind: ethereum/contract
+    name: EthFeeProxy_0_2_0
+    network: mantle
+    source:
+      address: "0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687"
+      abi: EthFeeProxy_0_2_0
+      startBlock: 127944
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthFeeProxy_0_2_0
+          file: ./abis/EthFeeProxy-0.2.0.json
+      eventHandlers:
+        - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+          receipt: true
+      file: ./src/ethFeeProxy.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,10 +623,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@requestnetwork/smart-contracts@0.29.1-next.1917":
-  version "0.29.1-next.1917"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.29.1-next.1917.tgz#96bcf3a4ed63e785166acb90427a3887d4fe0b9f"
-  integrity sha512-IyNPD1xCmH5y5sqsPhL8x4tBKjh1dmWo8XD3BFd4dUEkApAuySN+DVf3MQ1lw9iNoDMxI7YnGl6gZ9kmmy4xNw==
+"@requestnetwork/smart-contracts@0.29.1-next.1918":
+  version "0.29.1-next.1918"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.29.1-next.1918.tgz#3ba1636d06db10143f68c009b60e54ef5e2e0724"
+  integrity sha512-PXZVzLIKAlt7hzfsZ3EAizevYhsAR/kPa19Cl23L57KpX2pJ8ivyzhUG4YNp++FtHpsp3mBB/rPTzqA+jBSwLw==
   dependencies:
     tslib "2.5.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,10 +513,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@requestnetwork/smart-contracts@0.29.1-next.1869":
-  version "0.29.1-next.1869"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.29.1-next.1869.tgz#18c2adb7442474d5b3bd46c6da92345668e9ebd0"
-  integrity sha512-Uh3KQJuOLoqtU5obmK+/RioVXudsZWsYXpG5lr+NdTod3ZBBFFM9Lo1Gc1byl8bZI5bRXEELR+pDcm3PqTYhuQ==
+"@requestnetwork/smart-contracts@0.29.1-next.1917":
+  version "0.29.1-next.1917"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.29.1-next.1917.tgz#96bcf3a4ed63e785166acb90427a3887d4fe0b9f"
+  integrity sha512-IyNPD1xCmH5y5sqsPhL8x4tBKjh1dmWo8XD3BFd4dUEkApAuySN+DVf3MQ1lw9iNoDMxI7YnGl6gZ9kmmy4xNw==
   dependencies:
     tslib "2.5.0"
 


### PR DESCRIPTION
# Changes

* Add Mantle and Mantle Testnet chains
  * Including: ERC20Proxy, ERC20FeeProxy, EthereumProxy, and EthereumFeeProxy
* Update Deployment scripts
  * Use Mantle Foundation graph node for Mantle Testnet
  * Use FusionX graph node for Mantle
  * Add Optimism, Moonbeam, and Tombchain to the Github Action
* Update README: Add links to all subgraphs

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205287813636122