### PR TITLE
fix: add subgraph versioning

### DIFF
--- a/.github/actions/short-sha/action.yml
+++ b/.github/actions/short-sha/action.yml
@@ -1,0 +1,13 @@
+name: short-sha
+description: Compute release version
+runs:
+  using: composite
+  steps:
+    - id: short-sha
+      shell: sh
+      run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c 1-7`" >> $GITHUB_OUTPUT
+outputs:
+  hash:
+    description: The short Git HEAD hash
+    value: ${{ steps.short-sha.outputs.SHORT_SHA }}
+    

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn
+      - name: short-sha
+        description: Compute release version
+        runs:
+          using: composite
+          steps:
+            - id: short-sha
+              shell: sh
+              run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c 1-7`" >> $GITHUB_OUTPUT
+        outputs:
+          hash:
+            description: The short Git HEAD hash
+            value: ${{ steps.short-sha.outputs.SHORT_SHA }}
       - run: yarn subgraph deploy ${{ matrix.chain }}
         env:
           TOKEN: ${{ secrets.THEGRAPH_TOKEN }}
-          VERSION: ${{ github.sha }}
+          VERSION: ${{ steps.short-sha.outputs.hash }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 name: Deploy subgraph
 on:
-  push:
-    branches: ["main"]
+  release:
+    types: [published]
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,3 +29,4 @@ jobs:
       - run: yarn subgraph deploy ${{ matrix.chain }}
         env:
           TOKEN: ${{ secrets.THEGRAPH_TOKEN }}
+          VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,18 +26,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn
-      - name: short-sha
-        description: Compute release version
-        runs:
-          using: composite
-          steps:
-            - id: short-sha
-              shell: sh
-              run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c 1-7`" >> $GITHUB_OUTPUT
-        outputs:
-          hash:
-            description: The short Git HEAD hash
-            value: ${{ steps.short-sha.outputs.SHORT_SHA }}
+      - uses: ./.github/actions/short-sha
+        id: short-sha
       - run: yarn subgraph deploy ${{ matrix.chain }}
         env:
           TOKEN: ${{ secrets.THEGRAPH_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 name: Deploy subgraph
 on:
-  release:
-    types: [published]
+  push:
+    branches: ["main"]
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,4 +29,4 @@ jobs:
       - run: yarn subgraph deploy ${{ matrix.chain }}
         env:
           TOKEN: ${{ secrets.THEGRAPH_TOKEN }}
-          VERSION: ${{ github.event.release.tag_name }}
+          VERSION: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 This repo contains the code and configuration for Request Payment subgraphs:
 
 Mainnets:
-- [Mainnet](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-mainnet)
+- [Mainnet on the Hosted Service](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-mainnet)
+- [Mainnet on the Decentralized Network](https://thegraph.com/explorer/subgraphs/4cuRFnNSqAme2pVuBckSVQogQPXR8Wqw72AEC6TShLkc?view=Overview&chain=mainnet)
 - [Polygon (Matic)](https://thegraph.com/explorer/subgraph/requestnetwork/request-payments-matic)
 - [Celo](https://thegraph.com/explorer/subgraph/requestnetwork/request-payments-celo)
 - [BSC](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-bsc)
-- [Gnosis Chain (xDai)](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-xdai)
+- [Gnosis Chain (xDai) on the Hosted Service](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-xdai)
+- [Gnosis Chain (xDai) on the Decentralized Network](https://thegraph.com/explorer/subgraphs/KYY6Q6KTcqVpTXMgTyEQJEyYk7wex8BM6twbLzhCXjT?view=Overview&chain=mainnet)
 - [Fuse](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-fuse)
 - [Fantom](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-fantom)
 - [Near](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-near)
@@ -15,13 +17,13 @@ Mainnets:
 - [Optimism](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-optimism)
 - [Moonbeam](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-moonbeam)
 - [Arbitrum One](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-arbitrum-one)
-- [Mantle](https://graph.fusionx.finance/subgraphs/name/request-payments-mantle/graphql)
+- [Mantle](https://graph.fusionx.finance/subgraphs/name/request-payments-mantle)
 
 Testnets:
 - [Goerli](https://thegraph.com/explorer/subgraph/requestnetwork/request-payments-goerli)
 - [Near Testnet](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-near-testnet)
 - [Arbitrum Rinkeby](https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-arbitrum-rinkeby)
-- [Mantle Testnet](https://graph.testnet.mantle.xyz/subgraphs/name/request-payments-mantle-testnet/graphql)
+- [Mantle Testnet](https://graph.testnet.mantle.xyz/subgraphs/name/request-payments-mantle-testnet)
 
 It indexes Request's proxy smart-contracts for easy querying of payment data.
 
@@ -97,12 +99,21 @@ yarn deploy-local
 
 ### Networks
 
-The live deployment is automated for EVM chains on the hosted service.
-For test chains (goerli), it will be automatically deployed when pushed to `main`
+Some of the deployments are automated, others are manual
+#### Automated Deployment
+Deployment on EVM chains is semi-automated, when a Github release is published
 
-For production chains (all others), it is semi automatic, and requires a manual approval in [github actions](https://github.com/RequestNetwork/payments-subgraph/actions).
+* mantle-testnet uses the [graph node hosted by Mantle](https://docs.mantle.xyz/network/for-devs/resources-and-tooling/graph-endpoints).
+* mantle uses the [graph node hosted by FusionX](https://graph.fusionx.finance)
+* all other EVM chains use the hosted service.
 
-For non-EVM deployments, use:
+Test chains like Goerli and Mantle Testnet will be deployed immediately when a release is published.
+
+Mainnets (all others) require manual approval in [github actions](https://github.com/RequestNetwork/payments-subgraph/actions).
+
+#### Manual Deployment
+
+For non-EVM deployments like NEAR, use:
 
 ```
 yarn graph deploy --product hosted-service --deploy-key <GRAPH_KEY> requestnetwork/request-payments-<network> ./subgraph.<network>.yaml

--- a/cli/commands/deploy.ts
+++ b/cli/commands/deploy.ts
@@ -8,6 +8,7 @@ export const builder = (y: yargs.Argv) =>
   y
     .middleware(argv => {
       if (process.env.TOKEN) argv.token = process.env.TOKEN;
+      if (process.env.VERSION) argv.version = process.env.VERSION;
     }, true)
     .positional("network", {
       desc: "The network to deploy to",
@@ -24,6 +25,11 @@ export const builder = (y: yargs.Argv) =>
       type: "string",
       demandOption: true,
     })
+    .option("version", {
+      desc: "The subgraph version label, used by non-hosted service graph nodes",
+      type: "string",
+      demandOption: true,
+    })
     .check(({ all, network }) => {
       if (all && network)
         throw new Error("Cannot specify both -all and positional `network`");
@@ -35,6 +41,7 @@ export const handler = ({
   network,
   token,
   all,
+  version,
 }: Awaited<ReturnType<typeof builder>["argv"]>) => {
   const networkList = all ? networks : network || [];
   for (const net of networkList) {
@@ -48,6 +55,9 @@ export const handler = ({
           ipfs: "https://ipfs.testnet.mantle.xyz/",
           node: "https://graph.testnet.mantle.xyz/deploy/",
         },
+        {
+          "version-label": version,
+        },
       )
     } else if (net === "mantle") {
       deploySubgraph(
@@ -58,6 +68,9 @@ export const handler = ({
           ipfs: "https://api.thegraph.com/ipfs/",
           node: "https://deploy.graph.fusionx.finance/",
         },
+        {
+          "version-label": version,
+        }
       )
     } else {
       deploySubgraph(

--- a/cli/lib/deploy.ts
+++ b/cli/lib/deploy.ts
@@ -8,7 +8,8 @@ export const deploySubgraph = (
     ipfs: string;
   },
   options?: {
-    "access-token": string;
+    "access-token"?: string;
+    "version-label"?: string;
   }
 ) => {
   const argsString = Object.entries({...args, ...options})
@@ -16,7 +17,7 @@ export const deploySubgraph = (
     .join(" ");
 
   return execSync(
-    `npx graph deploy ${subgraphName} ${argsString}  ${manifestPath}`,
+    `npx graph deploy ${subgraphName} ${argsString} ${manifestPath}`,
     {
       stdio: "inherit",
     },


### PR DESCRIPTION
Resolves #62 

# Changes

* Add version-label to deploy script, to be used by non-hosted-service graph nodes.
* Change Github Action to be triggered **on published release** instead of on push to main
* Update README

# Non-changes

This PR does not add the manual deployments (NEAR on hosted service, Mainnet and Gnosis on Decentralized service) to Github Actions. This is left for a future PR.