### PR TITLE
fix: mantle network parameter

### DIFF
--- a/subgraph.mantle-testnet.yaml
+++ b/subgraph.mantle-testnet.yaml
@@ -4,7 +4,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: ERC20Proxy
-    network: mantle-testnet
+    network: testnet
     source:
       address: "0x88Ecc15fDC2985A7926171B938BB2Cd808A5ba40"
       abi: ERC20Proxy
@@ -25,7 +25,7 @@ dataSources:
       file: ./src/erc20Proxy.ts
   - kind: ethereum/contract
     name: ERC20FeeProxy_0_2_0
-    network: mantle-testnet
+    network: testnet
     source:
       address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
       abi: ERC20FeeProxy_0_2_0
@@ -46,7 +46,7 @@ dataSources:
       file: ./src/erc20FeeProxy.ts
   - kind: ethereum/contract
     name: EthProxy_0_3_0
-    network: mantle-testnet
+    network: testnet
     source:
       address: "0x171Ee0881407d4c0C11eA1a2FB7D5b4cdED71e6e"
       abi: EthProxy_0_3_0
@@ -67,7 +67,7 @@ dataSources:
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
     name: EthFeeProxy_0_2_0
-    network: mantle-testnet
+    network: testnet
     source:
       address: "0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687"
       abi: EthFeeProxy_0_2_0

--- a/subgraph.mantle.yaml
+++ b/subgraph.mantle.yaml
@@ -4,7 +4,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: ERC20Proxy
-    network: mantle
+    network: mainnet
     source:
       address: "0x88Ecc15fDC2985A7926171B938BB2Cd808A5ba40"
       abi: ERC20Proxy
@@ -25,7 +25,7 @@ dataSources:
       file: ./src/erc20Proxy.ts
   - kind: ethereum/contract
     name: ERC20FeeProxy_0_2_0
-    network: mantle
+    network: mainnet
     source:
       address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
       abi: ERC20FeeProxy_0_2_0
@@ -46,7 +46,7 @@ dataSources:
       file: ./src/erc20FeeProxy.ts
   - kind: ethereum/contract
     name: EthProxy_0_3_0
-    network: mantle
+    network: mainnet
     source:
       address: "0x171Ee0881407d4c0C11eA1a2FB7D5b4cdED71e6e"
       abi: EthProxy_0_3_0
@@ -67,7 +67,7 @@ dataSources:
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
     name: EthFeeProxy_0_2_0
-    network: mantle
+    network: mainnet
     source:
       address: "0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687"
       abi: EthFeeProxy_0_2_0


### PR DESCRIPTION
Towards #62

# Changes

* Changed Mantle Testnet network parameter to `testnet`, per [Mantle Graph Endpoint Docs](https://docs.mantle.xyz/network/for-devs/resources-and-tooling/graph-endpoints)
* Change Mantle network parameter to `mainnet`, per telegram message from Mantle.