### PR TITLE
feat: (2nd Attempt) fix mantle network

### DIFF
--- a/cli/commands/prepare.ts
+++ b/cli/commands/prepare.ts
@@ -12,8 +12,8 @@ export const handler = () => {
   for (const network of networks) {
     console.log(`parsing network ${network}`);
     const manifest = getManifest(
-      network,
-      network === "gnosis" ? "xdai" : network,
+      getTheGraphChainName(network),
+      getRequestNetworkChainName(network),
     );
     if (!manifest) {
       console.warn(`No contract found for ${network}`);
@@ -22,3 +22,23 @@ export const handler = () => {
     }
   }
 };
+
+const getTheGraphChainName = (chainName: string) => {
+  switch(chainName) {
+    case "mantle-testnet":
+      return "testnet";
+    case "mantle":
+      return "mainnet";
+    default:
+      return chainName;
+  }
+}
+
+const getRequestNetworkChainName = (chainName: string) => {
+  switch(chainName) {
+    case "gnosis":
+      return "xdai";
+    default:
+      return chainName;
+  }
+}

--- a/subgraph.mantle-testnet.yaml
+++ b/subgraph.mantle-testnet.yaml
@@ -4,7 +4,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: ERC20Proxy
-    network: testnet
+    network: mantle-testnet
     source:
       address: "0x88Ecc15fDC2985A7926171B938BB2Cd808A5ba40"
       abi: ERC20Proxy
@@ -25,7 +25,7 @@ dataSources:
       file: ./src/erc20Proxy.ts
   - kind: ethereum/contract
     name: ERC20FeeProxy_0_2_0
-    network: testnet
+    network: mantle-testnet
     source:
       address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
       abi: ERC20FeeProxy_0_2_0
@@ -46,7 +46,7 @@ dataSources:
       file: ./src/erc20FeeProxy.ts
   - kind: ethereum/contract
     name: EthProxy_0_3_0
-    network: testnet
+    network: mantle-testnet
     source:
       address: "0x171Ee0881407d4c0C11eA1a2FB7D5b4cdED71e6e"
       abi: EthProxy_0_3_0
@@ -67,7 +67,7 @@ dataSources:
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
     name: EthFeeProxy_0_2_0
-    network: testnet
+    network: mantle-testnet
     source:
       address: "0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687"
       abi: EthFeeProxy_0_2_0

--- a/subgraph.mantle.yaml
+++ b/subgraph.mantle.yaml
@@ -4,7 +4,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: ERC20Proxy
-    network: mainnet
+    network: mantle
     source:
       address: "0x88Ecc15fDC2985A7926171B938BB2Cd808A5ba40"
       abi: ERC20Proxy
@@ -25,7 +25,7 @@ dataSources:
       file: ./src/erc20Proxy.ts
   - kind: ethereum/contract
     name: ERC20FeeProxy_0_2_0
-    network: mainnet
+    network: mantle
     source:
       address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
       abi: ERC20FeeProxy_0_2_0
@@ -46,7 +46,7 @@ dataSources:
       file: ./src/erc20FeeProxy.ts
   - kind: ethereum/contract
     name: EthProxy_0_3_0
-    network: mainnet
+    network: mantle
     source:
       address: "0x171Ee0881407d4c0C11eA1a2FB7D5b4cdED71e6e"
       abi: EthProxy_0_3_0
@@ -67,7 +67,7 @@ dataSources:
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
     name: EthFeeProxy_0_2_0
-    network: mainnet
+    network: mantle
     source:
       address: "0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687"
       abi: EthFeeProxy_0_2_0


### PR DESCRIPTION
# Changes

* Add special cases to the prepare script to handle the mantle and mantle-testnet network names.
  * The Mantle Testnet Graph Node calls the network `testnet` but Request Network calls the network `mantle-testnet`
  * The Mantle Graph Node calls the network `mainnet`, but Request Network calls the network `mantle`.