### PR TITLE
fix: (4th Attempt) mantle and mantle-testnet urls

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ jobs:
       # Use Mantle Foundation graph node for Mantle Testnet
       # Use FuxionX graph node for Mantle
       # Use TheGraph Hosted Service for all other networks
-      url: ${{ matrix.chain == 'mantle-testnet' && 'https://graph.testnet.mantle.xyz/subgraphs/name/request-payments-mantle-testnet' || matrix.chain == 'mantle' && 'https://index.graph.fusionx.finance/subgraphs/name/request-payments-mantle' || format('https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-{0}', matrix.chain) }}
+      url: ${{ matrix.chain == 'mantle-testnet' && 'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet' || matrix.chain == 'mantle' && 'https://index.graph.fusionx.finance/subgraphs/name/requestnetwork/request-payments-mantle' || format('https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-{0}', matrix.chain) }}
     steps:
       - uses: actions/checkout@v3
       - name: Get yarn cache directory path

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Mainnets (all others) require manual approval in [github actions](https://github
 
 #### Manual Deployment
 
+The first time a subgraph is deployed to a non-hosted-service graph node, it needs to be created.
+
+For example:
+
+```bash
+yarn graph create --node https://deploy.graph.fusionx.finance requestnetwork/request-payments-mantle
+```
+
 For non-EVM deployments like NEAR, use:
 
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "codegen": "graph codegen ./subgraph.goerli.yaml; graph codegen ./subgraph.near.yaml -o ./generated/near/",
     "prepare": "yarn subgraph prepare && yarn codegen",
     "build": "graph build",
+    "create-mantle-testnet": "graph create --node https://graph.testnet.mantle.xyz/deploy/ requestnetwork/request-payments-mantle-testnet",
+    "create-mantle": "graph create --node https://deploy.graph.fusionx.finance requestnetwork/request-payments-mantle",
     "create-local": "graph create --node http://localhost:8020/ --access-token \"\" requestnetwork/request-payments-$NETWORK",
     "remove-local": "graph remove --node http://localhost:8020/ --access-token \"\" requestnetwork/request-payments-$NETWORK",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 requestnetwork/request-payments-$NETWORK ./subgraph.$NETWORK.yaml",


### PR DESCRIPTION
Fixes #62 

# Changes

* Document how to create a subgraph on a non-hosted-service graph node
* Fix URL for mantle-testnet and mantle; missing `requestnetwork/`