### PR TITLE
feat: core subgraph deployment

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -1,0 +1,30 @@
+name: deploy-base
+description: Subgraph base deployment actions
+inputs:
+  chain:
+    description: The chain to deploy the subgraph for
+    required: true
+  token:
+    description: Authentication token
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+    - uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - run: yarn
+    - uses: ./.github/actions/short-sha
+      id: short-sha
+    - run: yarn subgraph deploy ${{ input.chain }}
+      env:
+        TOKEN: ${{ input.token }}
+        VERSION: ${{ steps.short-sha.outputs.hash }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: ./.github/actions/deploy
         with:
-          - chain: ${{ matrix.chain }}
+          - chain: "core"
           - token: ${{ secrets.THEGRAPH_CORE_TOKEN }}
   deploy-mantle:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,31 +10,32 @@ jobs:
     strategy:
       matrix:
         chain:
-          [
-            "arbitrum-one",
-            "avalanche",
-            "bsc",
-            "celo",
-            "core",
-            "fantom",
-            "fuse",
-            "goerli",
-            "mainnet",
-            "mantle-testnet",
-            "mantle",
-            "matic",
-            "xdai",
-            "optimism",
-            "moonbeam",
-            "tombchain",
-          ]
+          - "arbitrum-one"
+          - "avalanche"
+          - "bsc"
+          - "celo"
+          - "core"
+          - "fantom"
+          - "fuse"
+          - "goerli"
+          - "mainnet"
+          - "mantle-testnet"
+          - "mantle"
+          - "matic"
+          - "xdai"
+          - "optimism"
+          - "moonbeam"
+          - "tombchain"
     environment:
       name: ${{ matrix.chain }}
       # Use Mantle Foundation graph node for Mantle Testnet
       # Use FuxionX graph node for Mantle
       # Use Core DAO Foundation graph node for Core
       # Use TheGraph Hosted Service for all other networks
-      url: ${{ matrix.chain == 'mantle-testnet' && 'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet' || matrix.chain == 'mantle' && 'https://graph.fusionx.finance/subgraphs/name/requestnetwork/request-payments-mantle' || matrix.chain === 'core' && 'https://thegraph.coredao.org/subgraphs/name/requestnetwork/request-payments-core' || format('https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-{0}', matrix.chain) }}
+      url: ${{ matrix.chain == 'mantle-testnet' && 'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet'
+               || matrix.chain == 'mantle' && 'https://graph.fusionx.finance/subgraphs/name/requestnetwork/request-payments-mantle'
+               || matrix.chain === 'core' && 'https://thegraph.coredao.org/subgraphs/name/requestnetwork/request-payments-core'
+               || format('https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-{0}', matrix.chain) }}
     steps:
       - uses: actions/checkout@v3
       - name: Get yarn cache directory path
@@ -51,5 +52,8 @@ jobs:
         id: short-sha
       - run: yarn subgraph deploy ${{ matrix.chain }}
         env:
-          TOKEN: ${{ matrix.chain == 'core' && secrets.THEGRAPH_CORE_TOKEN || secrets.THEGRAPH_TOKEN }}
+          TOKEN: ${{ matrix.chain == 'mantle-testnet' && "" 
+                     || matrix.chain == 'mantle' && ""
+                     || matrix.chain == 'core' && secrets.THEGRAPH_CORE_TOKEN
+                     || secrets.THEGRAPH_TOKEN }}
           VERSION: ${{ steps.short-sha.outputs.hash }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  deploy-hosted-service:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,8 +19,6 @@ jobs:
           - "fuse"
           - "goerli"
           - "mainnet"
-          - "mantle-testnet"
-          - "mantle"
           - "matic"
           - "xdai"
           - "optimism"
@@ -28,32 +26,38 @@ jobs:
           - "tombchain"
     environment:
       name: ${{ matrix.chain }}
+      # Use TheGraph Hosted Service for all networks
+      url: ${{ format('https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-{0}', matrix.chain) }}
+    steps:
+      - uses: ./.github/actions/deploy
+        with:
+          - chain: ${{ matrix.chain }}
+          - token: ${{ secrets.THEGRAPH_TOKEN }}
+  deploy-core:
+    runs-on: ubuntu-latest
+    environment:
+      name: core
+      # Use Core DAO Foundation graph node for Core
+      url: "https://thegraph.coredao.org/subgraphs/name/requestnetwork/request-payments-core"
+    steps:
+      - uses: ./.github/actions/deploy
+        with:
+          - chain: ${{ matrix.chain }}
+          - token: ${{ secrets.THEGRAPH_CORE_TOKEN }}
+  deploy-mantle:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chain:
+          - "mantle-testnet"
+          - "mantle"
+    environment:
+      name: ${{ matrix.chain }}
       # Use Mantle Foundation graph node for Mantle Testnet
       # Use FuxionX graph node for Mantle
-      # Use Core DAO Foundation graph node for Core
-      # Use TheGraph Hosted Service for all other networks
-      url: ${{ matrix.chain == 'mantle-testnet' && 'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet'
-               || matrix.chain == 'mantle' && 'https://graph.fusionx.finance/subgraphs/name/requestnetwork/request-payments-mantle'
-               || matrix.chain === 'core' && 'https://thegraph.coredao.org/subgraphs/name/requestnetwork/request-payments-core'
-               || format('https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-{0}', matrix.chain) }}
+      url: ${{ matrix.chain == 'mantle-testnet' && 'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet' || matrix.chain == 'mantle' && 'https://graph.fusionx.finance/subgraphs/name/requestnetwork/request-payments-mantle' }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v3
+      - uses: ./.github/actions/deploy
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - run: yarn
-      - uses: ./.github/actions/short-sha
-        id: short-sha
-      - run: yarn subgraph deploy ${{ matrix.chain }}
-        env:
-          TOKEN: ${{ matrix.chain == 'mantle-testnet' && "" 
-                     || matrix.chain == 'mantle' && ""
-                     || matrix.chain == 'core' && secrets.THEGRAPH_CORE_TOKEN
-                     || secrets.THEGRAPH_TOKEN }}
-          VERSION: ${{ steps.short-sha.outputs.hash }}
+          - chain: ${{ matrix.chain }}
+          - token: ""

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,13 +9,32 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chain: ["arbitrum-one", "avalanche", "bsc", "celo", "fantom", "fuse", "goerli", "mainnet", "mantle-testnet", "mantle", "matic", "xdai", "optimism", "moonbeam", "tombchain"]
+        chain:
+          [
+            "arbitrum-one",
+            "avalanche",
+            "bsc",
+            "celo",
+            "core",
+            "fantom",
+            "fuse",
+            "goerli",
+            "mainnet",
+            "mantle-testnet",
+            "mantle",
+            "matic",
+            "xdai",
+            "optimism",
+            "moonbeam",
+            "tombchain",
+          ]
     environment:
       name: ${{ matrix.chain }}
       # Use Mantle Foundation graph node for Mantle Testnet
       # Use FuxionX graph node for Mantle
+      # Use Core DAO Foundation graph node for Core
       # Use TheGraph Hosted Service for all other networks
-      url: ${{ matrix.chain == 'mantle-testnet' && 'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet' || matrix.chain == 'mantle' && 'https://graph.fusionx.finance/subgraphs/name/requestnetwork/request-payments-mantle' || format('https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-{0}', matrix.chain) }}
+      url: ${{ matrix.chain == 'mantle-testnet' && 'https://graph.testnet.mantle.xyz/subgraphs/name/requestnetwork/request-payments-mantle-testnet' || matrix.chain == 'mantle' && 'https://graph.fusionx.finance/subgraphs/name/requestnetwork/request-payments-mantle' || matrix.chain === 'core' && 'https://thegraph.coredao.org/subgraphs/name/requestnetwork/request-payments-core' || format('https://thegraph.com/hosted-service/subgraph/requestnetwork/request-payments-{0}', matrix.chain) }}
     steps:
       - uses: actions/checkout@v3
       - name: Get yarn cache directory path
@@ -32,5 +51,5 @@ jobs:
         id: short-sha
       - run: yarn subgraph deploy ${{ matrix.chain }}
         env:
-          TOKEN: ${{ secrets.THEGRAPH_TOKEN }}
+          TOKEN: ${{ matrix.chain == 'core' && secrets.THEGRAPH_CORE_TOKEN || secrets.THEGRAPH_TOKEN }}
           VERSION: ${{ steps.short-sha.outputs.hash }}

--- a/cli/graph-nodes.ts
+++ b/cli/graph-nodes.ts
@@ -8,15 +8,20 @@ type GraphNodeInfo = {
 type GraphNodeInfoByNetwork = Record<string, GraphNodeInfo>;
 
 export const graphNodeInfoByNetwork: GraphNodeInfoByNetwork = {
-  /* Graph Node maintained by Mantle Foundation:
-    https://docs.mantle.xyz/network/for-devs/resources-and-tooling/graph-endpoints */
+  /**
+   * Graph Node maintained by Mantle Foundation:
+   * https://docs.mantle.xyz/network/for-devs/resources-and-tooling/graph-endpoints
+   */
   "mantle-testnet": {
     queryBase: "https://graph.testnet.mantle.xyz",
     deploy: "https://graph.testnet.mantle.xyz/deploy",
     index: "https://graph.testnet.mantle.xyz/graphql",
     ipfs: "https://ipfs.testnet.mantle.xyz",
   },
-  // Graph Node maintained by FusionX: https://fusionx.finance/
+  /**
+   * Graph Node maintained by FusionX
+   * https://fusionx.finance/
+   */
   mantle: {
     queryBase: "https://graph.fusionx.finance",
     // FusionX Graph Node implements deploy endpoint as a subdomain
@@ -24,8 +29,10 @@ export const graphNodeInfoByNetwork: GraphNodeInfoByNetwork = {
     index: "https://graph.fusionx.finance/graphql",
     ipfs: "https://api.thegraph.com/ipfs",
   },
-  /* Graph Node maintained by CORE DAO:
-    https://docs.coredao.org/developer/develop-on-core/core-subgraph */
+  /**
+   * Graph Node maintained by CORE DAO:
+   * https://docs.coredao.org/developer/develop-on-core/core-subgraph
+   */
   core: {
     queryBase: "https://thegraph.coredao.org",
     // FusionX Graph Node implements deploy endpoint as a subdomain

--- a/cli/graph-nodes.ts
+++ b/cli/graph-nodes.ts
@@ -1,37 +1,46 @@
 type GraphNodeInfo = {
-    queryBase: string
-    deploy: string
-    index: string
-    ipfs: string
-}
+  queryBase: string;
+  deploy: string;
+  index: string;
+  ipfs: string;
+};
 
-type GraphNodeInfoByNetwork = Record<string, GraphNodeInfo>
+type GraphNodeInfoByNetwork = Record<string, GraphNodeInfo>;
 
 export const graphNodeInfoByNetwork: GraphNodeInfoByNetwork = {
-    /* Graph Node maintained by Mantle Foundation:
+  /* Graph Node maintained by Mantle Foundation:
     https://docs.mantle.xyz/network/for-devs/resources-and-tooling/graph-endpoints */
-    "mantle-testnet": {
-        queryBase: "https://graph.testnet.mantle.xyz",
-        deploy: "https://graph.testnet.mantle.xyz/deploy",
-        index: "https://graph.testnet.mantle.xyz/graphql",
-        ipfs: "https://ipfs.testnet.mantle.xyz",
-    },
-    // Graph Node maintained by FusionX: https://fusionx.finance/
-    "mantle": {
-        queryBase: "https://graph.fusionx.finance",
-        // FusionX Graph Node implements deploy endpoint as a subdomain
-        deploy: "https://deploy.graph.fusionx.finance",
-        index: "https://graph.fusionx.finance/graphql",
-        ipfs: "https://api.thegraph.com/ipfs",
-    }
-}
+  "mantle-testnet": {
+    queryBase: "https://graph.testnet.mantle.xyz",
+    deploy: "https://graph.testnet.mantle.xyz/deploy",
+    index: "https://graph.testnet.mantle.xyz/graphql",
+    ipfs: "https://ipfs.testnet.mantle.xyz",
+  },
+  // Graph Node maintained by FusionX: https://fusionx.finance/
+  mantle: {
+    queryBase: "https://graph.fusionx.finance",
+    // FusionX Graph Node implements deploy endpoint as a subdomain
+    deploy: "https://deploy.graph.fusionx.finance",
+    index: "https://graph.fusionx.finance/graphql",
+    ipfs: "https://api.thegraph.com/ipfs",
+  },
+  /* Graph Node maintained by CORE DAO:
+    https://docs.coredao.org/developer/develop-on-core/core-subgraph */
+  core: {
+    queryBase: "https://thegraph.coredao.org",
+    // FusionX Graph Node implements deploy endpoint as a subdomain
+    deploy: "https://thegraph.coredao.org/deploy/",
+    index: "https://thegraph.coredao.org/graphql",
+    ipfs: "https://thegraph.coredao.org/ipfs/",
+  },
+};
 
 // TheGraph Hosted Service
 export const defaultGraphNodeInfo: GraphNodeInfo = {
-    queryBase: "https://api.thegraph.com",
-    deploy: "https://api.thegraph.com/deploy",
-    /* TheGraph Hosted Service has a different endpoint for checking subgraph health.
+  queryBase: "https://api.thegraph.com",
+  deploy: "https://api.thegraph.com/deploy",
+  /* TheGraph Hosted Service has a different endpoint for checking subgraph health.
     https://thegraph.com/docs/en/deploying/deploying-a-subgraph-to-hosted/#checking-subgraph-health */
-    index: "https://api.thegraph.com/index-node/graphql",
-    ipfs: "https://api.thegraph.com/ipfs",
-}
+  index: "https://api.thegraph.com/index-node/graphql",
+  ipfs: "https://api.thegraph.com/ipfs",
+};

--- a/cli/networks.json
+++ b/cli/networks.json
@@ -14,5 +14,6 @@
   "gnosis",
   "optimism",
   "moonbeam",
-  "tombchain"
+  "tombchain",
+  "core"
 ]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.54.0",
     "@graphprotocol/graph-ts": "^0.27.0",
-    "@requestnetwork/smart-contracts": "0.29.1-next.1918",
+    "@requestnetwork/smart-contracts": "0.30.1-next.1944",
     "graphql-request": "^3.5.0",
     "ipfs-only-hash": "^4.0.0",
     "lodash": "^4.17.21"

--- a/subgraph.core.yaml
+++ b/subgraph.core.yaml
@@ -1,0 +1,89 @@
+specVersion: 0.0.5
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ERC20Proxy
+    network: core
+    source:
+      address: "0x88Ecc15fDC2985A7926171B938BB2Cd808A5ba40"
+      abi: ERC20Proxy
+      startBlock: 8317448
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: ERC20Proxy
+          file: ./abis/ERC20Proxy.json
+      eventHandlers:
+        - event: TransferWithReference(address,address,uint256,indexed bytes)
+          handler: handleTransferWithReference
+          receipt: true
+      file: ./src/erc20Proxy.ts
+  - kind: ethereum/contract
+    name: ERC20FeeProxy_0_2_0
+    network: core
+    source:
+      address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
+      abi: ERC20FeeProxy_0_2_0
+      startBlock: 8317450
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: ERC20FeeProxy_0_2_0
+          file: ./abis/ERC20FeeProxy-0.2.0.json
+      eventHandlers:
+        - event: TransferWithReferenceAndFee(address,address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+          receipt: true
+      file: ./src/erc20FeeProxy.ts
+  - kind: ethereum/contract
+    name: EthProxy_0_3_0
+    network: core
+    source:
+      address: "0x171Ee0881407d4c0C11eA1a2FB7D5b4cdED71e6e"
+      abi: EthProxy_0_3_0
+      startBlock: 8317443
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthProxy_0_3_0
+          file: ./abis/EthProxy-0.3.0.json
+      eventHandlers:
+        - event: TransferWithReference(address,uint256,indexed bytes)
+          handler: handleTransferWithReference
+          receipt: true
+      file: ./src/ethProxy.ts
+  - kind: ethereum/contract
+    name: EthFeeProxy_0_2_0
+    network: core
+    source:
+      address: "0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687"
+      abi: EthFeeProxy_0_2_0
+      startBlock: 8317446
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthFeeProxy_0_2_0
+          file: ./abis/EthFeeProxy-0.2.0.json
+      eventHandlers:
+        - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+          receipt: true
+      file: ./src/ethFeeProxy.ts
+  

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,10 +623,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@requestnetwork/smart-contracts@0.29.1-next.1918":
-  version "0.29.1-next.1918"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.29.1-next.1918.tgz#3ba1636d06db10143f68c009b60e54ef5e2e0724"
-  integrity sha512-PXZVzLIKAlt7hzfsZ3EAizevYhsAR/kPa19Cl23L57KpX2pJ8ivyzhUG4YNp++FtHpsp3mBB/rPTzqA+jBSwLw==
+"@requestnetwork/smart-contracts@0.30.1-next.1944":
+  version "0.30.1-next.1944"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.30.1-next.1944.tgz#bf449f554f7e3f22286c1a2c5ff607e6fd8edc0b"
+  integrity sha512-atO7Wi+iuyZHzDFtZ8Y/noPrqLi28GOo3P+P3LgS12VfL0e4SzVK4O545deBpz5oiwlFlH6oKYQlkLKO3x2NOQ==
   dependencies:
     tslib "2.5.0"
 


### PR DESCRIPTION
Deployment of the payment subgraph on Core for the following contracts:
- ERC20Proxy
- ERC20FeeProxy
- ETHProxy
- ETHFeeProxy

Config updated to use specific URLs for the subgraph node (managed by Core).
Config and gh repo updated to use Core specific auth token