### PR TITLE
feat: zksync subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ For decentralized network, use:
 yarn graph deploy --studio request-payments-<network> ./subgraph.<network>.yaml --version-label v1.<bumped-version>
 ```
 
+#### Manual Deployment of zkSync Era
+
+The network zkSync Era is only supported by The Graph's Subgraph Studio so the deployment is different.
+
+Step 1: Authenticate the graph-cli with subgraph studio. Get the studio token (here)[https://thegraph.com/studio/subgraph/request-payment-zksyncera/]
+```
+graph auth --studio <studio token>
+```
+Step 2: Deploy to subgraph studio
+```
+graph deploy --studio request-payment-zksyncera subgraph.zksyncera.yaml
+```
+
 ### Check the deployed version
 
 You can compare the code to the deployed version using one of these commands

--- a/cli/graph-nodes.ts
+++ b/cli/graph-nodes.ts
@@ -40,8 +40,16 @@ export const graphNodeInfoByNetwork: GraphNodeInfoByNetwork = {
     index: "https://thegraph.coredao.org/graphql",
     ipfs: "https://thegraph.coredao.org/ipfs/",
   },
+  // Zksync era deployment was done via subgraph studio
+  zksyncera: {
+    queryBase: "https://api.studio.thegraph.com/query/35843/request-payment-zksyncera/version/latest",
+    deploy: "",
+    index: "",
+    ipfs: ""
+  }
 };
 
+// Check different queryBase for Subgraph studio graphs and 
 // TheGraph Hosted Service
 export const defaultGraphNodeInfo: GraphNodeInfo = {
   queryBase: "https://api.thegraph.com",

--- a/cli/graph-nodes.ts
+++ b/cli/graph-nodes.ts
@@ -40,13 +40,6 @@ export const graphNodeInfoByNetwork: GraphNodeInfoByNetwork = {
     index: "https://thegraph.coredao.org/graphql",
     ipfs: "https://thegraph.coredao.org/ipfs/",
   },
-  // Zksync era deployment was done via subgraph studio
-  zksyncera: {
-    queryBase: "https://api.studio.thegraph.com/query/35843/request-payment-zksyncera/version/latest",
-    deploy: "",
-    index: "",
-    ipfs: ""
-  }
 };
 
 // TheGraph Hosted Service

--- a/cli/graph-nodes.ts
+++ b/cli/graph-nodes.ts
@@ -49,7 +49,6 @@ export const graphNodeInfoByNetwork: GraphNodeInfoByNetwork = {
   }
 };
 
-// Check different queryBase for Subgraph studio graphs and 
 // TheGraph Hosted Service
 export const defaultGraphNodeInfo: GraphNodeInfo = {
   queryBase: "https://api.thegraph.com",

--- a/cli/networks.json
+++ b/cli/networks.json
@@ -15,5 +15,6 @@
   "optimism",
   "moonbeam",
   "tombchain",
-  "core"
+  "core",
+  "zksync-era"
 ]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.54.0",
     "@graphprotocol/graph-ts": "^0.27.0",
-    "@requestnetwork/smart-contracts": "0.31.1-next.1960",
+    "@requestnetwork/smart-contracts": "0.31.1-next.1963",
     "graphql-request": "^3.5.0",
     "ipfs-only-hash": "^4.0.0",
     "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.54.0",
     "@graphprotocol/graph-ts": "^0.27.0",
-    "@requestnetwork/smart-contracts": "0.30.1-next.1944",
+    "@requestnetwork/smart-contracts": "0.31.1-next.1960",
     "graphql-request": "^3.5.0",
     "ipfs-only-hash": "^4.0.0",
     "lodash": "^4.17.21"

--- a/subgraph.zksyncera.yaml
+++ b/subgraph.zksyncera.yaml
@@ -1,0 +1,47 @@
+specVersion: 0.0.5
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ERC20FeeProxy_0_2_0
+    network: zksyncera
+    source:
+      address: "0x6e28Cc56C2E64c9250f39Cb134686C87dB196532"
+      abi: ERC20FeeProxy_0_2_0
+      startBlock: 19545285
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: ERC20FeeProxy_0_2_0
+          file: ./abis/ERC20FeeProxy-0.2.0.json
+      eventHandlers:
+        - event: TransferWithReferenceAndFee(address,address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+          receipt: true
+      file: ./src/erc20FeeProxy.ts
+  - kind: ethereum/contract
+    name: EthFeeProxy_0_2_0
+    network: zksyncera
+    source:
+      address: "0xE9A708db0D30409e39810C44cA240fd15cdA9b1a"
+      abi: EthFeeProxy_0_2_0
+      startBlock: 19545294
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Payment
+      abis:
+        - name: EthFeeProxy_0_2_0
+          file: ./abis/EthFeeProxy-0.2.0.json
+      eventHandlers:
+        - event: TransferWithReferenceAndFee(address,uint256,indexed bytes,uint256,address)
+          handler: handleTransferWithReferenceAndFee
+          receipt: true
+      file: ./src/ethFeeProxy.ts
+  

--- a/subgraph.zksyncera.yaml
+++ b/subgraph.zksyncera.yaml
@@ -4,7 +4,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: ERC20FeeProxy_0_2_0
-    network: zksyncera
+    network: zksync-era
     source:
       address: "0x6e28Cc56C2E64c9250f39Cb134686C87dB196532"
       abi: ERC20FeeProxy_0_2_0
@@ -25,7 +25,7 @@ dataSources:
       file: ./src/erc20FeeProxy.ts
   - kind: ethereum/contract
     name: EthFeeProxy_0_2_0
-    network: zksyncera
+    network: zksync-era
     source:
       address: "0xE9A708db0D30409e39810C44cA240fd15cdA9b1a"
       abi: EthFeeProxy_0_2_0

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,10 +623,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@requestnetwork/smart-contracts@0.31.1-next.1960":
-  version "0.31.1-next.1960"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.31.1-next.1960.tgz#519b3d402fd6eb9c2a951f25bed95fa3ad8f03ee"
-  integrity sha512-KQ69yqcy3DyljxgMbs5trk7Quhf3FtLY0MDt4xkPXZtfZMcpJ3SJ5veKTyr361MX98EjnaObmHYIN2es8x0QHQ==
+"@requestnetwork/smart-contracts@0.31.1-next.1963":
+  version "0.31.1-next.1963"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.31.1-next.1963.tgz#a4d7102f876bf99dacf6ede0ffb29c3827c0814a"
+  integrity sha512-Gy72xjKS6TOS6OHchaOAyLc/pM2nZkrOjqRHDqmF+IWCvCjOIhBUFE2LTHHHV876Ijegk1v8LlzHUusDE2zyOA==
   dependencies:
     tslib "2.5.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,10 +623,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@requestnetwork/smart-contracts@0.30.1-next.1944":
-  version "0.30.1-next.1944"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.30.1-next.1944.tgz#bf449f554f7e3f22286c1a2c5ff607e6fd8edc0b"
-  integrity sha512-atO7Wi+iuyZHzDFtZ8Y/noPrqLi28GOo3P+P3LgS12VfL0e4SzVK4O545deBpz5oiwlFlH6oKYQlkLKO3x2NOQ==
+"@requestnetwork/smart-contracts@0.31.1-next.1960":
+  version "0.31.1-next.1960"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.31.1-next.1960.tgz#519b3d402fd6eb9c2a951f25bed95fa3ad8f03ee"
+  integrity sha512-KQ69yqcy3DyljxgMbs5trk7Quhf3FtLY0MDt4xkPXZtfZMcpJ3SJ5veKTyr361MX98EjnaObmHYIN2es8x0QHQ==
   dependencies:
     tslib "2.5.0"
 


### PR DESCRIPTION
Bumped libraries and created subgraph config file for zkSyncEra.
ZK sync Era is only supported by The Graph's Subgraph studio, so our automated flow could not be used.
I updated the README with the instructions to update the zksync subgraph from [here](https://thegraph.com/studio/subgraph/request-payment-zksyncera/)