### PR TITLE
fix: missing imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "url": "git+https://github.com/RequestNetwork/requestNetwork.git"
   },
   "scripts": {
+    "clean": "rm -Rf ./build && rm -Rf ./generated",
     "codegen": "graph codegen ./subgraph.sepolia.yaml; graph codegen ./subgraph.near.yaml -o ./generated/near/",
-    "prepare": "yarn subgraph prepare && yarn codegen",
+    "prepare": "yarn clean && yarn subgraph prepare && yarn codegen",
     "build": "graph build",
     "create-mantle-testnet": "graph create --node https://graph.testnet.mantle.xyz/deploy/ requestnetwork/request-payments-mantle-testnet",
     "create-mantle": "graph create --node https://deploy.graph.fusionx.finance requestnetwork/request-payments-mantle",

--- a/src/erc20ConversionProxy.ts
+++ b/src/erc20ConversionProxy.ts
@@ -1,6 +1,6 @@
 import { BigDecimal, log } from "@graphprotocol/graph-ts";
 import { TransferWithConversionAndReference } from "../generated/ERC20ConversionProxy/ERC20ConversionProxy";
-import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy/ERC20FeeProxy";
+import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy_0_2_0/ERC20FeeProxy_0_2_0";
 import { Payment } from "../generated/schema";
 import { createPaymentForFeeProxy } from "./erc20FeeProxy";
 import { generateId } from "./shared";

--- a/src/erc20EscrowToPay.ts
+++ b/src/erc20EscrowToPay.ts
@@ -4,7 +4,7 @@ import {
   RequestFrozen,
   RevertedEmergencyClaim,
 } from "../generated/ERC20EscrowToPay/ERC20EscrowToPay";
-import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy/ERC20FeeProxy";
+import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy_0_2_0/ERC20FeeProxy_0_2_0";
 import { Escrow } from "../generated/schema";
 import { ERC20EscrowToPay } from "../generated/ERC20EscrowToPay/ERC20EscrowToPay";
 import { createPaymentForFeeProxy } from "./erc20FeeProxy";

--- a/src/erc20FeeProxy.ts
+++ b/src/erc20FeeProxy.ts
@@ -1,5 +1,5 @@
 import { ethereum, log } from "@graphprotocol/graph-ts";
-import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy/ERC20FeeProxy";
+import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy_0_2_0/ERC20FeeProxy_0_2_0";
 import { Escrow, Payment } from "../generated/schema";
 import { generateId, generateEscrowId, createEscrowEvent } from "./shared";
 

--- a/src/erc20Proxy.ts
+++ b/src/erc20Proxy.ts
@@ -1,5 +1,5 @@
 import { ethereum, log } from "@graphprotocol/graph-ts";
-import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy/ERC20FeeProxy";
+import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy_0_2_0/ERC20FeeProxy_0_2_0";
 import { Payment } from "../generated/schema";
 import { generateId } from "./shared";
 

--- a/src/erc20TransferrableReceivable.ts
+++ b/src/erc20TransferrableReceivable.ts
@@ -1,5 +1,5 @@
 import { log } from "@graphprotocol/graph-ts";
-import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy/ERC20FeeProxy";
+import { TransferWithReferenceAndFee } from "../generated/ERC20FeeProxy_0_2_0/ERC20FeeProxy_0_2_0";
 import { createPaymentForFeeProxy } from "./erc20FeeProxy";
 
 //

--- a/src/ethConversionProxy.ts
+++ b/src/ethConversionProxy.ts
@@ -1,6 +1,6 @@
 import { log } from "@graphprotocol/graph-ts";
-import { TransferWithConversionAndReference } from "../generated/EthConversionProxy/EthConversionProxy";
-import { TransferWithReferenceAndFee } from "../generated/EthFeeProxy/EthFeeProxy";
+import { TransferWithConversionAndReference } from "../generated/EthConversionProxy_0_2_0/EthConversionProxy_0_2_0";
+import { TransferWithReferenceAndFee } from "../generated/EthFeeProxy_0_2_0/EthFeeProxy_0_2_0";
 import { createPaymentForFeeProxy } from "./ethFeeProxy";
 import { Payment } from "../generated/schema";
 import { generateId } from "./shared";

--- a/src/ethFeeProxy.ts
+++ b/src/ethFeeProxy.ts
@@ -1,5 +1,5 @@
 import { ethereum, log } from "@graphprotocol/graph-ts";
-import { TransferWithReferenceAndFee } from "../generated/EthFeeProxy/EthFeeProxy";
+import { TransferWithReferenceAndFee } from "../generated/EthFeeProxy_0_2_0/EthFeeProxy_0_2_0";
 import { Payment } from "../generated/schema";
 import { generateId } from "./shared";
 

--- a/src/ethProxy.ts
+++ b/src/ethProxy.ts
@@ -1,5 +1,5 @@
 import { ethereum, log } from "@graphprotocol/graph-ts";
-import { TransferWithReference } from "../generated/EthProxy/EthProxy";
+import { TransferWithReference } from "../generated/EthProxy_0_3_0/EthProxy_0_3_0";
 import { Payment } from "../generated/schema";
 import { generateId } from "./shared";
 

--- a/subgraph.xdai.yaml
+++ b/subgraph.xdai.yaml
@@ -4,7 +4,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: ERC20FeeProxy
-    network: xdai
+    network: gnosis
     source:
       address: "0x0DfbEe143b42B41eFC5A6F87bFD1fFC78c2f0aC9"
       abi: ERC20FeeProxy
@@ -25,7 +25,7 @@ dataSources:
       file: ./src/erc20FeeProxy.ts
   - kind: ethereum/contract
     name: ERC20ConversionProxy
-    network: xdai
+    network: gnosis
     source:
       address: "0xf0f49873C50765239F6f9534Ba13c4fe16eD5f2E"
       abi: ERC20ConversionProxy
@@ -48,7 +48,7 @@ dataSources:
       file: ./src/erc20ConversionProxy.ts
   - kind: ethereum/contract
     name: EthProxy
-    network: xdai
+    network: gnosis
     source:
       address: "0x27c60BE17e853c47A9F1d280B05365f483c2dFAF"
       abi: EthProxy
@@ -69,7 +69,7 @@ dataSources:
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
     name: EthProxy_0_3_0
-    network: xdai
+    network: gnosis
     source:
       address: "0x322F0037d272E980984F89E94Aae43BD0FC065E6"
       abi: EthProxy_0_3_0
@@ -90,7 +90,7 @@ dataSources:
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
     name: EthFeeProxy_0_2_0
-    network: xdai
+    network: gnosis
     source:
       address: "0xfCFBcfc4f5A421089e3Df45455F7f4985FE2D6a8"
       abi: EthFeeProxy_0_2_0


### PR DESCRIPTION
This PR fixes the `yarn build` command, which [failed in the CI here](https://github.com/RequestNetwork/payments-subgraph/actions/runs/9266000158/job/25489251235). The command was working on my local environment because I had an old generated code that made the imports work. For this reason, I added a "clean" command that is executed at the beginning of the "prepare" command, so this discrepency should not happen again.