### PR TITLE
ci: do not cancel all jobs if one network fails

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,7 @@ jobs:
   deploy-thegraph-studio:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         chain:
           - "arbitrum-one"


### PR DESCRIPTION
Sometimes, the IPFS gateway of TheGraph times out for the deployment of one chain. In this case, we don't want to cancel every other job. We can retry the failed jobs later-on.