### PR TITLE
ci(mantle): do not cancel all jobs if one network fails 

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,6 +53,7 @@ jobs:
   deploy-mantle:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         chain:
           - "mantle-testnet"


### PR DESCRIPTION
Follow-up to https://github.com/RequestNetwork/payments-subgraph/pull/98 (same change but for the `mantle` matrix)