### PR TITLE
chore: migrate Mantle to 0xGraph

### DIFF
--- a/cli/graph-nodes.ts
+++ b/cli/graph-nodes.ts
@@ -25,9 +25,9 @@ export const graphNodeInfoByNetwork: GraphNodeInfoByNetwork = {
   mantle: {
     queryBase: "https://graph.fusionx.finance",
     // FusionX Graph Node implements deploy endpoint as a subdomain
-    deploy: "https://deploy.graph.fusionx.finance",
+    deploy: "https://subgraph-api.mantle.xyz/deploy",
     index: "https://graph.fusionx.finance/graphql",
-    ipfs: "https://api.thegraph.com/ipfs",
+    ipfs: "https://subgraph-api.mantle.xyz/ipfs",
   },
   /**
    * Graph Node maintained by CORE DAO:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "yarn clean && yarn subgraph prepare && yarn codegen",
     "build": "graph build",
     "create-mantle-testnet": "graph create --node https://graph.testnet.mantle.xyz/deploy/ requestnetwork/request-payments-mantle-testnet",
-    "create-mantle": "graph create --node https://deploy.graph.fusionx.finance requestnetwork/request-payments-mantle",
+    "create-mantle": "graph create --node https://subgraph-api.mantle.xyz/deploy requestnetwork/request-payments-mantle",
     "create-local": "graph create --node http://localhost:8020/ --access-token \"\" requestnetwork/request-payments-$NETWORK",
     "remove-local": "graph remove --node http://localhost:8020/ --access-token \"\" requestnetwork/request-payments-$NETWORK",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 requestnetwork/request-payments-$NETWORK ./subgraph.$NETWORK.yaml",
@@ -20,7 +20,7 @@
     "subgraph": "ts-node -r dotenv/config ./cli"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.72.1",
+    "@graphprotocol/graph-cli": "^0.81.0",
     "@graphprotocol/graph-ts": "^0.35.1",
     "@requestnetwork/smart-contracts": "0.36.1-next.2036",
     "graphql-request": "^3.5.0",

--- a/subgraph.mantle.yaml
+++ b/subgraph.mantle.yaml
@@ -4,7 +4,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: ERC20Proxy
-    network: mainnet
+    network: mantle
     source:
       address: "0x88Ecc15fDC2985A7926171B938BB2Cd808A5ba40"
       abi: ERC20Proxy
@@ -25,7 +25,7 @@ dataSources:
       file: ./src/erc20Proxy.ts
   - kind: ethereum/contract
     name: ERC20FeeProxy_0_2_0
-    network: mainnet
+    network: mantle
     source:
       address: "0x399F5EE127ce7432E4921a61b8CF52b0af52cbfE"
       abi: ERC20FeeProxy_0_2_0
@@ -46,7 +46,7 @@ dataSources:
       file: ./src/erc20FeeProxy.ts
   - kind: ethereum/contract
     name: EthProxy_0_3_0
-    network: mainnet
+    network: mantle
     source:
       address: "0x171Ee0881407d4c0C11eA1a2FB7D5b4cdED71e6e"
       abi: EthProxy_0_3_0
@@ -67,7 +67,7 @@ dataSources:
       file: ./src/ethProxy.ts
   - kind: ethereum/contract
     name: EthFeeProxy_0_2_0
-    network: mainnet
+    network: mantle
     source:
       address: "0xe11BF2fDA23bF0A98365e1A4c04A87C9339e8687"
       abi: EthFeeProxy_0_2_0
@@ -86,4 +86,3 @@ dataSources:
           handler: handleTransferWithReferenceAndFee
           receipt: true
       file: ./src/ethFeeProxy.ts
-  

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,10 +402,10 @@
     graphql-import-node "^0.0.5"
     js-yaml "^4.1.0"
 
-"@graphprotocol/graph-cli@^0.72.1":
-  version "0.72.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.72.1.tgz#d80bb8459a60ab34a49ede34ee5e022ee88124ea"
-  integrity sha512-9TpzgPBEC3sK6S0gyUS3Rz+HrrWwocJLjnGg2hCMbNJS+lvTbzeLyvGgxsK6z20KehD2Lbpe8imGUJmlnt5WBw==
+"@graphprotocol/graph-cli@^0.81.0":
+  version "0.81.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.81.0.tgz#4728b38d155e8d59ab33fddf2cb7c1e1305ae679"
+  integrity sha512-jIH36P+OwHmSLAPPMq0KyGHr3gGK0HadJoqZmi22GqOWce8mh7cWp0rHykSGwrVftUBDD9IEYu1kI0ibpGXOLg==
   dependencies:
     "@float-capital/float-subgraph-uncrashable" "^0.0.0-alpha.4"
     "@oclif/core" "2.8.6"
@@ -427,6 +427,7 @@
     ipfs-http-client "55.0.0"
     jayson "4.0.0"
     js-yaml "3.14.1"
+    open "8.4.2"
     prettier "3.0.3"
     semver "7.4.0"
     sync-request "6.1.0"
@@ -1589,6 +1590,11 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 delay@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
@@ -2499,7 +2505,7 @@ is-core-module@^2.5.0, is-core-module@^2.9.0:
   dependencies:
     has "^1.0.3"
 
-is-docker@^2.0.0:
+is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
@@ -3236,6 +3242,15 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 ora@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Resolves https://github.com/RequestNetwork/payments-subgraph/issues/90

Please approve as-is because this was the state of the Repo when I deployed. I'll clean up the mantle stuff in a future PR.

# Changes

- Upgrade `@graphprotocol/graph-cli` to 0.81.0
- Fix `mantle.subgraph.yaml` to use `mantle` network name
- Hack the mantle config in `cli/graph-nodes.ts` and the `create-mantle` script in `package.json`. These hacks were ultimately unused. Deployed manually instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated deployment and IPFS endpoints for the Mantle network to enhance service reliability.
	- Shifted Ethereum contract data sources from the mainnet to the Mantle network for improved performance and scalability.

- **Bug Fixes**
	- Upgraded the Graph CLI dependency to leverage new features and improvements.

These changes aim to optimize the deployment process and enhance user experience in managing subgraphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->