### PR TITLE
feat: add `SingleRequestProxyFactory` subgraph

### DIFF
--- a/abis/SingleRequestProxyFactory.json
+++ b/abis/SingleRequestProxyFactory.json
@@ -1,0 +1,282 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_ethereumFeeProxy",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_erc20FeeProxy",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newERC20FeeProxy",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20FeeProxyUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "proxyAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "payee",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes",
+        "name": "paymentReference",
+        "type": "bytes"
+      }
+    ],
+    "name": "ERC20SingleRequestProxyCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newEthereumFeeProxy",
+        "type": "address"
+      }
+    ],
+    "name": "EthereumFeeProxyUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "proxyAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "payee",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes",
+        "name": "paymentReference",
+        "type": "bytes"
+      }
+    ],
+    "name": "EthereumSingleRequestProxyCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_payee",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_paymentReference",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "_feeAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_feeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "createERC20SingleRequestProxy",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_payee",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_paymentReference",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "_feeAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_feeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "createEthereumSingleRequestProxy",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "erc20FeeProxy",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ethereumFeeProxy",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newERC20FeeProxy",
+        "type": "address"
+      }
+    ],
+    "name": "setERC20FeeProxy",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newEthereumFeeProxy",
+        "type": "address"
+      }
+    ],
+    "name": "setEthereumFeeProxy",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.81.0",
     "@graphprotocol/graph-ts": "^0.35.1",
-    "@requestnetwork/smart-contracts": "0.38.1-next.2071",
+    "@requestnetwork/smart-contracts": "^0.38.1-next.2082",
     "graphql-request": "^3.5.0",
     "ipfs-only-hash": "^4.0.0",
     "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.81.0",
     "@graphprotocol/graph-ts": "^0.35.1",
-    "@requestnetwork/smart-contracts": "^0.38.1-next.2082",
+    "@requestnetwork/smart-contracts": "0.38.1-next.2082",
     "graphql-request": "^3.5.0",
     "ipfs-only-hash": "^4.0.0",
     "lodash": "^4.17.21"

--- a/schema.graphql
+++ b/schema.graphql
@@ -69,13 +69,18 @@ type EscrowEvent @entity {
   gasPrice: BigInt!
 }
 
+enum SingleRequestProxyType {
+  Ethereum
+  ERC20
+}
+
 type SingleRequestProxyDeployment @entity {
   id: ID!
   proxyAddress: Bytes!
   payee: Bytes!
   tokenAddress: Bytes
   paymentReference: Bytes!
-  proxyType: String! # "Ethereum" or "ERC20"
+  proxyType: SingleRequestProxyType!
   block: Int!
   timestamp: Int!
   txHash: Bytes!

--- a/schema.graphql
+++ b/schema.graphql
@@ -68,3 +68,15 @@ type EscrowEvent @entity {
   gasUsed: BigInt!
   gasPrice: BigInt!
 }
+
+type SingleRequestProxyDeployment @entity {
+  id: ID!
+  proxyAddress: Bytes!
+  payee: Bytes!
+  tokenAddress: Bytes
+  paymentReference: Bytes!
+  proxyType: String! # "Ethereum" or "ERC20"
+  block: Int!
+  timestamp: Int!
+  txHash: Bytes!
+}

--- a/src/singleRequestProxyFactory.ts
+++ b/src/singleRequestProxyFactory.ts
@@ -1,0 +1,38 @@
+import {
+  ERC20SingleRequestProxyCreated,
+  EthereumSingleRequestProxyCreated,
+} from "../generated/SingleRequestProxyFactory/SingleRequestProxyFactory";
+import { SingleRequestProxyDeployment } from "../generated/schema";
+
+export function handleEthereumSingleRequestProxyCreated(
+  event: EthereumSingleRequestProxyCreated,
+): void {
+  let deployment = new SingleRequestProxyDeployment(
+    event.transaction.hash.toHexString(),
+  );
+  deployment.proxyAddress = event.params.proxyAddress;
+  deployment.payee = event.params.payee;
+  deployment.paymentReference = event.params.paymentReference;
+  deployment.proxyType = "Ethereum";
+  deployment.block = event.block.number.toI32();
+  deployment.timestamp = event.block.timestamp.toI32();
+  deployment.txHash = event.transaction.hash;
+  deployment.save();
+}
+
+export function handleERC20SingleRequestProxyCreated(
+  event: ERC20SingleRequestProxyCreated,
+): void {
+  let deployment = new SingleRequestProxyDeployment(
+    event.transaction.hash.toHexString(),
+  );
+  deployment.proxyAddress = event.params.proxyAddress;
+  deployment.payee = event.params.payee;
+  deployment.tokenAddress = event.params.tokenAddress;
+  deployment.paymentReference = event.params.paymentReference;
+  deployment.proxyType = "ERC20";
+  deployment.block = event.block.number.toI32();
+  deployment.timestamp = event.block.timestamp.toI32();
+  deployment.txHash = event.transaction.hash;
+  deployment.save();
+}

--- a/subgraph.sepolia.yaml
+++ b/subgraph.sepolia.yaml
@@ -164,4 +164,28 @@ dataSources:
           handler: handleTransferWithReferenceAndFee
           receipt: true
       file: ./src/erc20EscrowToPay.ts
+  - kind: ethereum/contract
+    name: SingleRequestProxyFactory
+    network: sepolia
+    source:
+      address: "0x435E81E12136414e2c09cAFe05E902E23bD46030"
+      abi: SingleRequestProxyFactory
+      startBlock: 6965557
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - SingleRequestProxyDeployment
+      abis:
+        - name: SingleRequestProxyFactory
+          file: ./abis/SingleRequestProxyFactory.json
+      eventHandlers:
+        - event: ERC20SingleRequestProxyCreated(address,address,address,indexed bytes)
+          handler: handleERC20SingleRequestProxyCreated
+          receipt: true
+        - event: EthereumSingleRequestProxyCreated(address,address,indexed bytes)
+          handler: handleEthereumSingleRequestProxyCreated
+          receipt: true
+      file: ./src/singleRequestProxyFactory.ts
   

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,7 +677,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@requestnetwork/smart-contracts@^0.38.1-next.2082":
+"@requestnetwork/smart-contracts@0.38.1-next.2082":
   version "0.38.1-next.2082"
   resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.38.1-next.2082.tgz#59410c1df57a7bd6639f8914926e3ec0cc030514"
   integrity sha512-g6zzm2rQWWV23inY01+wHM3R6Y15NiBnCYe9eJOt8Dj2oFXkEIV0PZZJyGDMhmOI2sfuhISChWQrqbi2gB5/NQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,10 +677,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@requestnetwork/smart-contracts@0.38.1-next.2071":
-  version "0.38.1-next.2071"
-  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.38.1-next.2071.tgz#d6962f79c4fe12ba4f5b86a720d1ad9dc5ed4e5b"
-  integrity sha512-tHoNmLzSFwiAQKVRSEW5eYw26G2muUwi2QAlV+c3XV9FNhfnegA6+5IOe9+8zlBJ6+FXl5byTfP9Ys9p8IQG7w==
+"@requestnetwork/smart-contracts@^0.38.1-next.2082":
+  version "0.38.1-next.2082"
+  resolved "https://registry.yarnpkg.com/@requestnetwork/smart-contracts/-/smart-contracts-0.38.1-next.2082.tgz#59410c1df57a7bd6639f8914926e3ec0cc030514"
+  integrity sha512-g6zzm2rQWWV23inY01+wHM3R6Y15NiBnCYe9eJOt8Dj2oFXkEIV0PZZJyGDMhmOI2sfuhISChWQrqbi2gB5/NQ==
   dependencies:
     tslib "2.5.0"
 


### PR DESCRIPTION
- Add the `SingleRequestProxyFactory` artifact to the manifest.
- Generate new sepolia subgraph config
- Add a new entity for `SingleRequestProxyDeployments`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced the `SingleRequestProxyFactory`, enabling the creation of single request proxies for Ethereum and ERC20 tokens.
  - Added new event handlers to track the creation of single request proxies.
  - New entity type `SingleRequestProxyDeployment` added to the GraphQL schema for better tracking of proxy deployments.

- **Updates**
  - Enhanced payment network handling with the addition of `SingleRequestProxyFactory` in the manifest.
  - Updated dependency version for improved compatibility.

- **Bug Fixes**
  - Expanded ignored events to streamline event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->