### PR TITLE
chore: update Node.js version in GitHub Actions from 20 to 22

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -14,7 +14,7 @@ runs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
         cache: yarn
     - name: install packages
       shell: sh


### PR DESCRIPTION
## Problem

Deploy github action is failling as Request Network SDK now requires node version 22: https://github.com/RequestNetwork/payments-subgraph/actions/runs/20264718046/job/58184997535

## Changes

Upgrade node version on github action workflow 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version in deployment configuration from version 20 to version 22.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->